### PR TITLE
Allow passing data directory via the command-line

### DIFF
--- a/platform/main2.c
+++ b/platform/main2.c
@@ -501,19 +501,22 @@ int main(int argc, char **argv)
 	initSdl();
 	
 	// C3 setup
-    if (!game_pre_init()) {
-        // change to "../data" and try again
-        char cwd[200];
-        getcwd(cwd, 200);
-        printf("Trying again in ../data; current working directory: %s\n", cwd);
-        if (chdir("../data") != 0) {
-            printf("data directory not found!\n");
-            return 1;
-        }
-        if (!game_pre_init()) {
-            return 1;
-        }
-    }
+	if (!game_pre_init()) {
+		if (argc > 1 && argv[1]) {
+			if (chdir(argv[1]) != 0) {
+				printf("%s: directory not found!\n", argv[1]);
+				return 1;
+			}
+		} else {
+			if (chdir("../data") != 0) {
+				printf("../data: directory not found!\n");
+				return 1;
+			}
+		}
+		if (!game_pre_init()) {
+			return 1;
+		}
+	}
 	
 	int width, height;
 	setting_window(&width, &height);


### PR DESCRIPTION
This is a simple patch I use locally.  Requiring the data directory
directly above the executable is difficult especially when built as a
system pacakge.

Ideally this would use BSD's err.h for the err(3) API but I mostly kept
it in line with what is currently there and provided the fall back to
`../data` which should keep things working as usual.