### PR TITLE
Add hotkeys "Page Up" and "Page Down" to increase/decrease game speed.

### DIFF
--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -283,6 +283,16 @@ void hotkey_esc(void)
     window_popup_dialog_show(POPUP_DIALOG_QUIT, confirm_exit, 1);
 }
 
+void hotkey_page_up(void)
+{
+	change_game_speed(0);
+}
+
+void hotkey_page_down(void)
+{
+	change_game_speed(1);
+}
+
 static void go_to_bookmark(int number)
 {
     if (map_bookmark_go_to(number)) {

--- a/src/input/hotkey.h
+++ b/src/input/hotkey.h
@@ -10,6 +10,8 @@ void hotkey_down(void);
 void hotkey_home(void);
 void hotkey_end(void);
 void hotkey_esc(void);
+void hotkey_page_up(void);
+void hotkey_page_down(void);
 
 void hotkey_func(int f_number);
 

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -55,6 +55,12 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
             keyboard_end();
             hotkey_end();
             break;
+        case SDLK_PAGEUP:
+            hotkey_page_up();
+            break;
+        case SDLK_PAGEDOWN:
+            hotkey_page_down();
+            break;
         case SDLK_ESCAPE:
             hotkey_esc();
             break;


### PR DESCRIPTION
The old "[" and "]" hotkeys still work. However those hotkeys do not work for international keyboards, hence the workaround.

This does not really fix issue #37, as international keyboards are still not properly supported (in my keyboard, the chief advisor cannot be accessed via hotkey), but it at least help with setting the game speed. 