### PR TITLE
When creating a new building, set all its internal data to zero.

### DIFF
--- a/src/building/building.c
+++ b/src/building/building.c
@@ -67,6 +67,8 @@ building *building_create(building_type type, int x, int y)
     
     const building_properties *props = building_properties_for_type(type);
     
+    memset(&(b->data), 0, sizeof(b->data));
+
     b->state = BUILDING_STATE_CREATED;
     b->faction_id = 1;
     b->unknown_value = city_buildings_unknown_value();


### PR DESCRIPTION
This prevents a bug which caused new buildings to have random values when a different city was loaded in the same playthrough.

This was very visible when a mission was won and a new one started.

In those cases, when new houses were created  on the new, empty map and people started moving in, the tents could appear with for example 90 pottery, 150 furniture and access to education and other services and would therefore instantly evolve to insulaes.

An alternative fix to this bug is to change `read_type_data` in `building\building_state.c` to not simply skip reading the buffer on building types that don't use some of the data, but actually populating the data with `0`.