### PR TITLE
Change the way window invalidation works. Fixes bug with victory screen not displaying.

### DIFF
--- a/src/game/game.c
+++ b/src/game/game.c
@@ -124,6 +124,10 @@ void game_run(void)
     for (int i = 0; i < num_ticks; i++) {
         game_tick_run();
         game_file_write_mission_saved_game();
+
+        if (window_must_refresh()) {
+            break;
+        }
     }
 }
 

--- a/src/graphics/tooltip.c
+++ b/src/graphics/tooltip.c
@@ -44,7 +44,7 @@ static void reset_tooltip(tooltip_context *c)
 {
     if (c->type != TOOLTIP_NONE) {
         c->type = TOOLTIP_NONE;
-        window_invalidate();
+        window_request_refresh_on_draw();
     }
 }
 

--- a/src/graphics/window.c
+++ b/src/graphics/window.c
@@ -9,7 +9,8 @@
 static window_type window_queue[MAX_QUEUE];
 static int queue_index = 0;
 static window_type *current_window = 0;
-static int refresh_requested;
+static int refresh_immediate;
+static int refresh_on_draw;
 
 static void noop(void)
 {
@@ -36,7 +37,18 @@ static void decrease_queue_index(void)
 
 void window_invalidate(void)
 {
-    refresh_requested = 1;
+    refresh_immediate = 1;
+    refresh_on_draw = 1;
+}
+
+int window_must_refresh(void)
+{
+    return refresh_immediate;
+}
+
+void window_request_refresh_on_draw(void)
+{
+    refresh_on_draw = 1;
 }
 
 int window_is(window_id id)
@@ -87,9 +99,10 @@ static void update_mouse_after(void)
 void window_draw(int force)
 {
     update_mouse_before();
-    if (force || refresh_requested) {
+    if (force || refresh_on_draw) {
         current_window->draw_background();
-        refresh_requested = 0;
+        refresh_on_draw = 0;
+        refresh_immediate = 0;
     }
     current_window->draw_foreground();
 

--- a/src/graphics/window.h
+++ b/src/graphics/window.h
@@ -57,6 +57,10 @@ typedef struct {
 
 void window_invalidate(void);
 
+void window_request_refresh_on_draw(void);
+
+int window_must_refresh(void);
+
 void window_draw(int force);
 
 int window_is(window_id id);

--- a/src/widget/sidebar.c
+++ b/src/widget/sidebar.c
@@ -428,7 +428,7 @@ static void update_progress(void)
 
 static void draw_sliding_foreground(void)
 {
-    window_invalidate();
+    window_request_refresh_on_draw();
     update_progress();
     if (data.progress >= 47) {
         city_view_toggle_sidebar();

--- a/test/stub/ui.c
+++ b/test/stub/ui.c
@@ -29,6 +29,11 @@ window_id window_get_id(void)
     return WINDOW_CITY;
 }
 
+int window_must_refresh(void)
+{
+    return 0;
+}
+
 void window_draw(int force)
 {}
 


### PR DESCRIPTION
There are now two types of window invalidation:
- An immediate invalidation, which prevents any further ticks from occuring until the screen is refreshed;
- An invalidation "on draw", which allows the remaining game ticks to be processed before redrawing the screen (the way window invalidation worked before this commit).

Reasoning for the change:

With the old code, there was a bug with window drawing when game speed was set to >100%.
Specifically, the victory screen did not appear and instead the victory video showed immediately (with no chance to continue governing).

The bug was due to the fact that when victory conditions were met, a value that the victory popup was shown was set to true (`city_data.mission.victory_message_shown` was set to `1`).
After that, the screen was invalidated to draw the victory dialog.
However, since when game speed is set to >100%, the game processes more than one tick per frame, it kept running the city and went back to the victory condiction routine (`city_victory_check` in `victory.c`) and, as the popup was set to already having been shown, the game loaded the victory video without ever loading the victory popup.

By setting two different possible timings to a redraw request in `game_run` (either after the current tick was processed or after all the remaning ticks for the frame have been processed), the game is able to immediately show popup windows and prevent the city to keep running in the background until the next frame was shown.

Also, certain elements, like tooltips and the sidebar scrolling, do not cause the game to pause like most windows do, therefore they do not need to interrupt the ticks when speed is over 100%. Doing so would reduce the speed to 1 tick per frame (effectively 100% speed) when a tooltip was shown or the sidebar scrolled.
Therefore, those elements are only redrawn after all ticks have been processed, behaving like all the windows did before this commit.

This may also prevent all sorts of different bugs with game speed over 100%, for example if two message dialogs arrived in different ticks of the same frame, one of them might be ignored.