### PR TITLE
Improve game save/load/delete dialog.

### DIFF
--- a/src/graphics/font.h
+++ b/src/graphics/font.h
@@ -13,7 +13,8 @@ typedef enum {
     FONT_LARGE_BROWN,
     FONT_SMALL_PLAIN,
     FONT_NORMAL_GREEN,
-    FONT_SMALL_BLACK
+    FONT_SMALL_BLACK,
+    FONT_TYPES_MAX
 } font_t;
 
 typedef struct {

--- a/src/graphics/text.h
+++ b/src/graphics/text.h
@@ -11,6 +11,7 @@ void text_capture_cursor(int cursor_position);
 void text_draw_cursor(int x_offset, int y_offset, int is_insert);
 
 int text_get_width(const uint8_t *str, font_t font);
+void text_ellipsize(char *str, font_t font, int requested_width);
 
 int text_draw(const uint8_t *str, int x, int y, font_t font, color_t color);
 

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -45,7 +45,8 @@ static generic_button file_buttons[] = {
     {160, 304, 448, 320, GB_IMMEDIATE, button_select_file, button_none, 11, 0},
 };
 
-#define NOT_EXIST_MESSAGE_TIMEOUT 500
+static const int NOT_EXIST_MESSAGE_TIMEOUT = 500;
+static const int MAX_FILE_WINDOW_TEXT_WIDTH = 18 * 16;
 
 static struct {
     time_millis message_not_exist_start_time;
@@ -92,7 +93,7 @@ static void draw_scrollbar_dot(void)
 static void draw_foreground(void)
 {
     graphics_in_dialog();
-    char file[100];
+    char file[FILE_NAME_MAX];
 
     outer_panel_draw(128, 40, 24, 21);
     inner_panel_draw(144, 80, 20, 2);
@@ -113,8 +114,9 @@ static void draw_foreground(void)
         if (data.focus_button_id == i + 1) {
             font = FONT_NORMAL_WHITE;
         }
-        strcpy(file, data.saved_games->files[data.scroll_position + i]);
+        strncpy(file, data.saved_games->files[data.scroll_position + i], FILE_NAME_MAX);
         file_remove_extension(file);
+        text_ellipsize(file, font, MAX_FILE_WINDOW_TEXT_WIDTH);
         text_draw(string_from_ascii(file), 160, 130 + 16 * i, font, 0);
     }
 


### PR DESCRIPTION
- Fix a crash when long (>100 chars) file names are used;
- Prevent file name's sizes from overflowing the file list window (the text input with the selected file still overflows, though).