### PR TITLE
Handle atomic mouse up+down in the city widget.

### DIFF
--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -173,9 +173,11 @@ void widget_city_handle_mouse(const mouse *m)
         }
     } else if (m->left.is_down) {
         build_move(tile);
-    } else if (m->left.went_up) {
+    }
+    if (m->left.went_up) {
         build_end();
-    } else if (m->right.went_up) {
+    }
+    if (m->right.went_up) {
         if (handle_right_click_allow_building_info(tile)) {
             window_building_info_show(tile->grid_offset);
         }


### PR DESCRIPTION
Greetings!

When playing Julius with a laptop trackpad, I cannot "build" a building using a tap, but must use a hard click instead. This seems to be because taps are delivered to the event loop as simultaneous (or nearly simultaneous) "down" and "up" events.

When I tap, the game does a build_start() but nothing else, leaving a hole in the ground until the next click, which then abandons the build action.

The fix is easy: replace the "if (went down), else if (went up)" with "if, if".

I am not sure if this proposal exactly matches the behavior of the original Caesar III. Trackpad taps are also complicated there, and don't always work. In any case they don't leave the tile in a "hole in the ground" state.

Thanks for reading! 🙂