### PR TITLE
increases max walkers, buildings, and routes 4x

### DIFF
--- a/src/building/building.h
+++ b/src/building/building.h
@@ -4,7 +4,7 @@
 #include "building/type.h"
 #include "core/buffer.h"
 
-#define MAX_BUILDINGS 2000
+#define MAX_BUILDINGS 8000
 
 typedef struct {
     int id;

--- a/src/figure/figure.h
+++ b/src/figure/figure.h
@@ -6,7 +6,7 @@
 #include "figure/action.h"
 #include "figure/type.h"
 
-#define MAX_FIGURES 1000
+#define MAX_FIGURES 4000
 
 typedef struct {
     int id;

--- a/src/figure/route.c
+++ b/src/figure/route.c
@@ -4,7 +4,7 @@
 #include "map/routing_path.h"
 
 #define MAX_PATH_LENGTH 500
-#define MAX_ROUTES 600
+#define MAX_ROUTES 2400
 
 static struct {
     int figure_ids[MAX_ROUTES];


### PR DESCRIPTION
It is well-known within the community that there is a hard cap on the number of builders, walkers, and routes:

* [Heaven Games Thread 1](http://caesar3.heavengames.com/cgi-bin/forums/display.cgi?action=ct&f=2,3608,2175,all)
* [Heaven Games Thread 2](http://caesar3.heavengames.com/cgi-bin/forums/display.cgi?action=ct&f=2,6184,1250,all&st=recent)
* [Steam Community](https://steamcommunity.com/app/517790/discussions/0/350540974011956646/)
* [Reddit Community](https://www.reddit.com/r/impressionsgames/comments/1qq5vw/caesar_iii_recap_on_building_and_walker_limit/)

These limits seem to have been motivated by ancient PC hardware that was round in the year 1998. Load this saved game and try to build a few hundred new houses. This PR increases those limits 4x.

[- data limit test.zip](https://github.com/bvschaik/julius/files/2819629/-.data.limit.test.zip)

I understand that this is a deviation from the behavior of the original game, so feel free to reject this PR and I'll harbor no ill will!