### PR TITLE
Change Travis configuration to include both recent and old SDL libraries and to test Mac OS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,57 @@
 language: c
 
-compiler:
-  - gcc
-  - clang
+matrix:
+  include:
+  - os: linux
+    compiler: gcc
+    env: SDL_LIB=SDL2-2.0.9 SDL_MIXER_LIB=SDL2_mixer-2.0.4
+  - os: linux
+    compiler: gcc
+    env: SDL_LIB=SDL2-2.0.0 SDL_MIXER_LIB=SDL2_mixer-2.0.0
+  - os: linux
+    compiler: clang
+    env: SDL_LIB=SDL2-2.0.9 SDL_MIXER_LIB=SDL2_mixer-2.0.4
+  - os: osx
+    compiler: clang
+    env: SDL_LIB=SDL2-2.0.9 SDL_MIXER_LIB=SDL2_mixer-2.0.4
 
 install: true
 
-addons:
-  apt:
-    packages:
-    - libsdl2-2.0-0
-    - libsdl2-dev
-    - libsdl2-mixer-2.0-0
-    - libsdl2-mixer-dev
+cache:
+  directories:
+  - $SDL_LIB
+  - $SDL_MIXER_LIB
+
+before_install:
+- function install_sdl_lib {
+    if [ -d $1/build ];
+    then
+      cp -r $1 $1-final;
+      cd $1-final/build;
+    else
+      if [[ $1 == SDL2-* ]];
+      then
+        SDL_LIB_URL=https://www.libsdl.org/release/$1.tar.gz;
+      else
+        SDL_LIB_URL=${1#*_};
+        SDL_LIB_URL=${SDL_LIB_URL%-*};
+        SDL_LIB_URL=https://www.libsdl.org/projects/SDL_$SDL_LIB_URL/release/$1.tar.gz;
+      fi;
+      travis_retry curl -L $SDL_LIB_URL | tar xz;
+      cd $1;
+      mkdir build;
+      cd build;
+      ../configure;
+    fi;
+    make;
+    sudo make install;
+    cd ../..;
+  }
+- install_sdl_lib $SDL_LIB
+- install_sdl_lib $SDL_MIXER_LIB
 
 before_script:
-  - mkdir build
-  - cd build
-  - cmake ..
+  - mkdir build && cd build && cmake ..
 
 script:
   - make


### PR DESCRIPTION
Instead of downloading the SDL and SDL_mixer libs from apt, their sources are now directly downloaded from libsdl.org. After being compiled, the resulting binaries are cached for faster build times in subsequent builds.

Two versions of both libs are compiled in two separate jobs: The most current version and the original 2.0.0 version. This allows SDL API calls that are not compatible with older versions of SDL to be detected.

Also add a Mac OS X build using clang.