### PR TITLE
Silence some Visual Studio specific warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,10 @@ add_executable(julius
 find_package(SDL2 REQUIRED)
 find_package(SDL2_mixer REQUIRED)
 
+if(MSVC)
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
 include_directories(${SDL2_INCLUDE_DIR})
 include_directories(${SDL2_MIXER_INCLUDE_DIR})
 


### PR DESCRIPTION
Visual Studio constantly throws warning `C4996` which complains that some standard functions like `fopen` and `strcpy`, among others, are deprecated and `fopen_s` or `strcpy_s` should be used instead.

Since those `_s` functions are not standard, the warning doesn't make much sense to me.

This pull request aims to silence those warnings, making the Visual Studio build much cleaner.