### PR TITLE
Videos now play with volume settings of 'sound effects'

### DIFF
--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -1,5 +1,6 @@
 #include "core/log.h"
 #include "sound/device.h"
+#include "game/settings.h"
 #include "SDL.h"
 #include "SDL_mixer.h"
 
@@ -174,7 +175,9 @@ static int next_audio_frame(void)
         SDL_ConvertAudio(&custom_music.cvt);
         custom_music.cur = 0;
         custom_music.len = custom_music.cvt.len_cvt;
-        custom_music.data = custom_music.cvt.buf;
+        custom_music.data = (Uint8*) malloc(custom_music.len);
+        memset(custom_music.data, 0, custom_music.len);
+        SDL_MixAudioFormat(custom_music.data, custom_music.cvt.buf, AUDIO_FORMAT, custom_music.cvt.len_cvt, setting_sound(SOUND_EFFECTS)->volume);
         custom_music.cvt.buf = 0;
         custom_music.cvt.len = 0;
     }


### PR DESCRIPTION
The SMK raw stream gets converted to the SDL format with the given AUDIO_FORMAT (=AUDIO_S16MSB). 
Before the converted audio chunk gets passed its volume is being mixed with the settings for 'sound effects'.
