### PR TITLE
Change the information window position when a city tile is right-clicked.

### DIFF
--- a/src/window/building/common.c
+++ b/src/window/building/common.c
@@ -4,10 +4,54 @@
 #include "building/model.h"
 #include "city/labor.h"
 #include "city/population.h"
+#include "city/view.h"
 #include "graphics/image.h"
 #include "graphics/lang_text.h"
+#include "graphics/screen.h"
 #include "graphics/text.h"
 #include "sound/speech.h"
+
+void window_building_set_possible_position(int *x_offset, int *y_offset, int width_blocks, int height_blocks)
+{
+    int dialog_width = 16 * width_blocks;
+    int dialog_height = 16 * height_blocks;
+    int stub;
+    int width;
+    city_view_get_viewport(&stub, &stub, &width, &stub);
+    width -= MARGIN_POSITION;
+
+    if (*y_offset + dialog_height > screen_height() - MARGIN_POSITION) {
+        *y_offset -= dialog_height;
+    }
+
+    *y_offset = (*y_offset < MIN_Y_POSITION) ? MIN_Y_POSITION : *y_offset;
+
+    if (*x_offset + dialog_width > width) {
+        *x_offset = width - dialog_width;
+    }
+}
+
+int window_building_get_vertical_offset(building_info_context *c, int new_window_height)
+{
+    new_window_height = new_window_height * 16;
+    int old_window_height = c->height_blocks * 16;
+    int y_offset = c->y_offset;
+
+    int center = (old_window_height / 2) + y_offset;
+    int new_window_y = center - (new_window_height / 2);
+
+    if (new_window_y < MIN_Y_POSITION) {
+        new_window_y = MIN_Y_POSITION;
+    } else {
+        int height = screen_height() - MARGIN_POSITION;
+
+        if (new_window_y + new_window_height > height) {
+            new_window_y = height - new_window_height;
+        }
+    }
+
+    return new_window_y;
+}
 
 void window_building_draw_employment(building_info_context *c, int y_offset)
 {

--- a/src/window/building/common.h
+++ b/src/window/building/common.h
@@ -1,6 +1,9 @@
 #ifndef WINDOW_BUILDING_COMMON_H
 #define WINDOW_BUILDING_COMMON_H
 
+static const int MIN_Y_POSITION = 32;
+static const int MARGIN_POSITION = 16;
+
 typedef enum {
     BUILDING_INFO_NONE = 0,
     BUILDING_INFO_TERRAIN = 1,
@@ -58,6 +61,10 @@ typedef struct {
         int figure_ids[7];
     } figure;
 } building_info_context;
+
+void window_building_set_possible_position(int * x_offset, int * y_offset, int width_blocks, int height_blocks);
+
+int window_building_get_vertical_offset(building_info_context *c, int new_window_height);
 
 void window_building_draw_employment(building_info_context *c, int y_offset);
 

--- a/src/window/building/distribution.c
+++ b/src/window/building/distribution.c
@@ -223,20 +223,22 @@ void window_building_handle_mouse_granary(const mouse *m, building_info_context 
 void window_building_draw_granary_orders(building_info_context *c)
 {
     c->help_id = 3;
-    outer_panel_draw(c->x_offset, 32, 29, 28);
-    lang_text_draw_centered(98, 6, c->x_offset, 42, 16 * c->width_blocks, FONT_LARGE_BLACK);
-    inner_panel_draw(c->x_offset + 16, 74, c->width_blocks - 2, 21);
+    int y_offset = window_building_get_vertical_offset(c, 28);
+    outer_panel_draw(c->x_offset, y_offset, 29, 28);
+    lang_text_draw_centered(98, 6, c->x_offset, y_offset + 10, 16 * c->width_blocks, FONT_LARGE_BLACK);
+    inner_panel_draw(c->x_offset + 16, y_offset + 42, c->width_blocks - 2, 21);
 }
 
 void window_building_draw_granary_orders_foreground(building_info_context *c)
 {
-    button_border_draw(c->x_offset + 80, 436, 16 * (c->width_blocks - 10), 20, data.orders_focus_button_id == 1 ? 1 : 0);
+    int y_offset = window_building_get_vertical_offset(c, 28);
+    button_border_draw(c->x_offset + 80, y_offset + 404, 16 * (c->width_blocks - 10), 20, data.orders_focus_button_id == 1 ? 1 : 0);
     const building_storage *storage = building_storage_get(building_get(c->building_id)->storage_id);
     if (storage->empty_all) {
-        lang_text_draw_centered(98, 8, c->x_offset + 80, 440, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
-        lang_text_draw_centered(98, 9, c->x_offset + 80, 416, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
+        lang_text_draw_centered(98, 8, c->x_offset + 80, y_offset + 408, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
+        lang_text_draw_centered(98, 9, c->x_offset + 80, y_offset + 384, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
     } else {
-        lang_text_draw_centered(98, 7, c->x_offset + 80, 440, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
+        lang_text_draw_centered(98, 7, c->x_offset + 80, y_offset + 408, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
     }
 
     const resource_list *list = city_resource_get_available_foods();
@@ -244,33 +246,35 @@ void window_building_draw_granary_orders_foreground(building_info_context *c)
         int resource = list->items[i];
         int image_id = image_group(GROUP_RESOURCE_ICONS) + resource +
             resource_image_offset(resource, RESOURCE_IMAGE_ICON);
-        image_draw(image_id, c->x_offset + 32, 78 + 22 * i);
-        image_draw(image_id, c->x_offset + 408, 78 + 22 * i);
-        lang_text_draw(23, resource, c->x_offset + 72, 82 + 22 * i, FONT_NORMAL_WHITE);
-        button_border_draw(c->x_offset + 180, 78 + 22 * i, 210, 22, data.resource_focus_button_id == i + 1);
-        
+        image_draw(image_id, c->x_offset + 32, y_offset + 46 + 22 * i);
+        image_draw(image_id, c->x_offset + 408, y_offset + 46 + 22 * i);
+        lang_text_draw(23, resource, c->x_offset + 72, y_offset + 50 + 22 * i, FONT_NORMAL_WHITE);
+        button_border_draw(c->x_offset + 180, y_offset + 46 + 22 * i, 210, 22, data.resource_focus_button_id == i + 1);
+
         int state = storage->resource_state[resource];
         if (state == BUILDING_STORAGE_STATE_ACCEPTING) {
-            lang_text_draw(99, 7, c->x_offset + 230, 83 + 22 * i, FONT_NORMAL_WHITE);
+            lang_text_draw(99, 7, c->x_offset + 230, y_offset + 51 + 22 * i, FONT_NORMAL_WHITE);
         } else if (state == BUILDING_STORAGE_STATE_NOT_ACCEPTING) {
-            lang_text_draw(99, 8, c->x_offset + 230, 83 + 22 * i, FONT_NORMAL_RED);
+            lang_text_draw(99, 8, c->x_offset + 230, y_offset + 51 + 22 * i, FONT_NORMAL_RED);
         } else if (state == BUILDING_STORAGE_STATE_GETTING) {
             image_draw(image_group(GROUP_CONTEXT_ICONS) + 12,
-                c->x_offset + 186, 81 + 22 * i);
-            lang_text_draw(99, 10, c->x_offset + 230, 83 + 22 * i, FONT_NORMAL_WHITE);
+                c->x_offset + 186, y_offset + 49 + 22 * i);
+            lang_text_draw(99, 10, c->x_offset + 230, y_offset + 51 + 22 * i, FONT_NORMAL_WHITE);
         }
     }
 }
 
 void window_building_handle_mouse_granary_orders(const mouse *m, building_info_context *c)
 {
+    int y_offset = window_building_get_vertical_offset(c, 28);
+
     data.building_id = c->building_id;
-    if (generic_buttons_handle_mouse(m, c->x_offset + 180, 78,
+    if (generic_buttons_handle_mouse(m, c->x_offset + 180, y_offset + 46,
         orders_resource_buttons, city_resource_get_available_foods()->size,
         &data.resource_focus_button_id)) {
         return;
     }
-    generic_buttons_handle_mouse(m, c->x_offset + 80, 436, granary_order_buttons, 1, &data.orders_focus_button_id);
+    generic_buttons_handle_mouse(m, c->x_offset + 80, y_offset + 404, granary_order_buttons, 1, &data.orders_focus_button_id);
 }
 
 void window_building_draw_warehouse(building_info_context *c)
@@ -344,58 +348,63 @@ void window_building_handle_mouse_warehouse(const mouse *m, building_info_contex
 
 void window_building_draw_warehouse_orders(building_info_context *c)
 {
+    int y_offset = window_building_get_vertical_offset(c, 28);
     c->help_id = 4;
-    outer_panel_draw(c->x_offset, 32, 29, 28);
-    lang_text_draw_centered(99, 3, c->x_offset, 42, 16 * c->width_blocks, FONT_LARGE_BLACK);
-    inner_panel_draw(c->x_offset + 16, 74, c->width_blocks - 2, 21);
+    outer_panel_draw(c->x_offset, y_offset, 29, 28);
+    lang_text_draw_centered(99, 3, c->x_offset, y_offset + 10, 16 * c->width_blocks, FONT_LARGE_BLACK);
+    inner_panel_draw(c->x_offset + 16, y_offset + 42, c->width_blocks - 2, 21);
 }
 
 void window_building_draw_warehouse_orders_foreground(building_info_context *c)
 {
-    button_border_draw(c->x_offset + 80, 436, 16 * (c->width_blocks - 10), 20, data.orders_focus_button_id == 1 ? 1 : 0);
+    int y_offset = window_building_get_vertical_offset(c, 28);
+
+    button_border_draw(c->x_offset + 80, y_offset + 404, 16 * (c->width_blocks - 10), 20, data.orders_focus_button_id == 1 ? 1 : 0);
     const building_storage *storage = building_storage_get(building_get(c->building_id)->storage_id);
     if (storage->empty_all) {
-        lang_text_draw_centered(99, 5, c->x_offset + 80, 440, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
-        lang_text_draw_centered(99, 6, c->x_offset + 80, 458, 16 * (c->width_blocks - 10), FONT_SMALL_PLAIN);
+        lang_text_draw_centered(99, 5, c->x_offset + 80, y_offset + 408, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
+        lang_text_draw_centered(99, 6, c->x_offset + 80, y_offset + 426, 16 * (c->width_blocks - 10), FONT_SMALL_PLAIN);
     } else {
-        lang_text_draw_centered(99, 4, c->x_offset + 80, 440, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
+        lang_text_draw_centered(99, 4, c->x_offset + 80, y_offset + 408, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
     }
 
     // trade center
-    button_border_draw(c->x_offset + 80, 414, 16 * (c->width_blocks - 10), 20, data.orders_focus_button_id == 2 ? 1 : 0);
+    button_border_draw(c->x_offset + 80, y_offset + 382, 16 * (c->width_blocks - 10), 20, data.orders_focus_button_id == 2 ? 1 : 0);
     int is_trade_center = c->building_id == city_buildings_get_trade_center();
-    lang_text_draw_centered(99, is_trade_center ? 11 : 12, c->x_offset + 80, 418, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
+    lang_text_draw_centered(99, is_trade_center ? 11 : 12, c->x_offset + 80, y_offset + 386, 16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
 
     const resource_list *list = city_resource_get_available();
     for (int i = 0; i < list->size; i++) {
         int resource = list->items[i];
         int image_id = image_group(GROUP_RESOURCE_ICONS) + resource + resource_image_offset(resource, RESOURCE_IMAGE_ICON);
-        image_draw(image_id, c->x_offset + 32, 78 + 22 * i);
-        image_draw(image_id, c->x_offset + 408, 78 + 22 * i);
-        lang_text_draw(23, resource, c->x_offset + 72, 82 + 22 * i, FONT_NORMAL_WHITE);
-        button_border_draw(c->x_offset + 180, 78 + 22 * i, 210, 22, data.resource_focus_button_id == i + 1);
+        image_draw(image_id, c->x_offset + 32, y_offset + 46 + 22 * i);
+        image_draw(image_id, c->x_offset + 408, y_offset + 46 + 22 * i);
+        lang_text_draw(23, resource, c->x_offset + 72, y_offset + 50 + 22 * i, FONT_NORMAL_WHITE);
+        button_border_draw(c->x_offset + 180, y_offset + 46 + 22 * i, 210, 22, data.resource_focus_button_id == i + 1);
 
         int state = storage->resource_state[resource];
         if (state == BUILDING_STORAGE_STATE_ACCEPTING) {
-            lang_text_draw(99, 7, c->x_offset + 230, 83 + 22 * i, FONT_NORMAL_WHITE);
+            lang_text_draw(99, 7, c->x_offset + 230, y_offset + 51 + 22 * i, FONT_NORMAL_WHITE);
         } else if (state == BUILDING_STORAGE_STATE_NOT_ACCEPTING) {
-            lang_text_draw(99, 8, c->x_offset + 230, 83 + 22 * i, FONT_NORMAL_RED);
+            lang_text_draw(99, 8, c->x_offset + 230, y_offset + 51 + 22 * i, FONT_NORMAL_RED);
         } else if (state == BUILDING_STORAGE_STATE_GETTING) {
-            image_draw(image_group(GROUP_CONTEXT_ICONS) + 12, c->x_offset + 186, 81 + 22 * i);
-            lang_text_draw(99, 9, c->x_offset + 230, 83 + 22 * i, FONT_NORMAL_WHITE);
+            image_draw(image_group(GROUP_CONTEXT_ICONS) + 12, c->x_offset + 186, y_offset + 49 + 22 * i);
+            lang_text_draw(99, 9, c->x_offset + 230, y_offset + 51 + 22 * i, FONT_NORMAL_WHITE);
         }
     }
 }
 
 void window_building_handle_mouse_warehouse_orders(const mouse *m, building_info_context *c)
 {
+    int y_offset = window_building_get_vertical_offset(c, 28);
+
     data.building_id = c->building_id;
-    if (generic_buttons_handle_mouse(m, c->x_offset + 180, 78,
+    if (generic_buttons_handle_mouse(m, c->x_offset + 180, y_offset + 46,
         orders_resource_buttons, city_resource_get_available()->size,
         &data.resource_focus_button_id)) {
         return;
     }
-    generic_buttons_handle_mouse(m, c->x_offset + 80, 436, warehouse_order_buttons, 2, &data.orders_focus_button_id);
+    generic_buttons_handle_mouse(m, c->x_offset + 80, y_offset + 404, warehouse_order_buttons, 2, &data.orders_focus_button_id);
 }
 
 static void go_to_orders(int param1, int param2)

--- a/src/window/building_info.c
+++ b/src/window/building_info.c
@@ -314,8 +314,6 @@ static void init(int grid_offset)
         }
     }
     // dialog size
-    context.x_offset = 8;
-    context.y_offset = 32;
     context.width_blocks = 29;
     switch (get_height_id()) {
         case 1: context.height_blocks = 16; break;
@@ -325,15 +323,18 @@ static void init(int grid_offset)
         default: context.height_blocks = 22; break;
     }
     // dialog placement
+    int s_width = screen_width();
     int s_height = screen_height();
-    if (s_height >= 600) {
-        if (mouse_get()->y <= (s_height - 24) / 2 + 24) {
-            context.y_offset = s_height - 16 * context.height_blocks - 16;
-        } else {
-            context.y_offset = 32;
-        }
-    }
     context.x_offset = center_in_city(16 * context.width_blocks);
+    if (s_width >= 1024 && s_height >= 768) {
+        context.x_offset = mouse_get()->x;
+        context.y_offset = mouse_get()->y;
+        window_building_set_possible_position(&context.x_offset, &context.y_offset, context.width_blocks, context.height_blocks);
+    } else if (s_height >= 600 && mouse_get()->y <= (s_height - 24) / 2 + 24) {
+        context.y_offset = s_height - 16 * context.height_blocks - MARGIN_POSITION;
+    } else {
+        context.y_offset = MIN_Y_POSITION;
+    }
 }
 
 static void draw_background(void)
@@ -509,7 +510,8 @@ static void draw_foreground(void)
     }
     // general buttons
     if (context.storage_show_special_orders) {
-        image_buttons_draw(context.x_offset, 432, image_buttons_help_close, 2);
+        int y_offset = window_building_get_vertical_offset(&context, 28);
+        image_buttons_draw(context.x_offset, y_offset + 400, image_buttons_help_close, 2);
     } else {
         image_buttons_draw(context.x_offset, context.y_offset + 16 * context.height_blocks - 40, image_buttons_help_close, 2);
     }
@@ -526,7 +528,8 @@ static void handle_mouse(const mouse *m)
     }
     // general buttons
     if (context.storage_show_special_orders) {
-        image_buttons_handle_mouse(m, context.x_offset, 432, image_buttons_help_close, 2, &focus_image_button_id);
+        int y_offset = window_building_get_vertical_offset(&context, 28);
+        image_buttons_handle_mouse(m, context.x_offset, y_offset + 400, image_buttons_help_close, 2, &focus_image_button_id);
     } else {
         image_buttons_handle_mouse(
             m, context.x_offset, context.y_offset + 16 * context.height_blocks - 40,


### PR DESCRIPTION
This is a small cosmetic change, but one I had already implemented in my Pharaoh widescreen mod and I think makes the GUI a little bit better.

With this change, the information window's position is set to the mouse posiition (instead being centered either at the top or at the bottom of the screen), except if it would not fit in the window. In terms of positioning, it behaves very much like a right-click context menu.

The "special orders" menus have also been changed to appear depending on the information window position (something I couldn't implement in Pharaoh widescreen because assembly).