### PR TITLE
Slightly optimize video drawing and line drawing.

### DIFF
--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -189,54 +189,60 @@ void graphics_clear_screen(void)
     memset(canvas.pixels, 0, sizeof(color_t) * canvas.width * canvas.height);
 }
 
-void graphics_draw_pixel(int x, int y, color_t color)
+void graphics_draw_vertical_line(int x, int y1, int y2, color_t color)
 {
-    if (x >= clip_rectangle.x_start && x < clip_rectangle.x_end) {
-        if (y >= clip_rectangle.y_start && y < clip_rectangle.y_end) {
-            *graphics_get_pixel(x, y) = color;
-        }
+    if (x < clip_rectangle.x_start || x >= clip_rectangle.x_end) {
+        return;
+    }
+    int y_min = y1 < y2 ? y1 : y2;
+    int y_max = y1 < y2 ? y2 : y1;
+    y_min = y_min < clip_rectangle.y_start ? clip_rectangle.y_start : y_min;
+    y_max = y_max > clip_rectangle.y_end ? clip_rectangle.y_end : y_max;
+    color_t *pixel = graphics_get_pixel(x, y_min);
+    color_t *end_pixel = pixel + ((y_max - y_min)  * canvas.width);
+    while (pixel <= end_pixel) {
+        *pixel = color;
+        pixel += canvas.width;
     }
 }
 
-void graphics_draw_line(int x1, int y1, int x2, int y2, color_t color)
+void graphics_draw_horizontal_line(int x1, int x2, int y, color_t color)
 {
-    if (x1 == x2) {
-        int y_min = y1 < y2 ? y1 : y2;
-        int y_max = y1 < y2 ? y2 : y1;
-        for (int y = y_min; y <= y_max; y++) {
-            graphics_draw_pixel(x1, y, color);
-        }
-    } else if (y1 == y2) {
-        int x_min = x1 < x2 ? x1 : x2;
-        int x_max = x1 < x2 ? x2 : x1;
-        for (int x = x_min; x <= x_max; x++) {
-            graphics_draw_pixel(x, y1, color);
-        }
-    } else {
-        // non-straight line: ignore
+    if (y < clip_rectangle.y_start || y >= clip_rectangle.y_end) {
+        return;
+    }
+    int x_min = x1 < x2 ? x1 : x2;
+    int x_max = x1 < x2 ? x2 : x1;
+    x_min = x_min < clip_rectangle.x_start ? clip_rectangle.x_start : x_min;
+    x_max = x_max > clip_rectangle.x_end ? clip_rectangle.x_end : x_max;
+    color_t *pixel = graphics_get_pixel(x_min, y);
+    color_t *end_pixel = pixel + (x_max - x_min);
+    while (pixel <= end_pixel) {
+        *pixel = color;
+        ++pixel;
     }
 }
 
 void graphics_draw_rect(int x, int y, int width, int height, color_t color)
 {
-    graphics_draw_line(x, y, x + width - 1, y, color);
-    graphics_draw_line(x, y + height - 1, x + width - 1, y + height - 1, color);
-    graphics_draw_line(x, y, x, y + height - 1, color);
-    graphics_draw_line(x + width - 1, y, x + width - 1, y + height - 1, color);
+    graphics_draw_horizontal_line(x, x + width - 1, y, color);
+    graphics_draw_horizontal_line(x, x + width - 1, y + height - 1, color);
+    graphics_draw_vertical_line(x, y, y + height - 1, color);
+    graphics_draw_vertical_line(x + width - 1, y, y + height - 1, color);
 }
 
 void graphics_draw_inset_rect(int x, int y, int width, int height)
 {
-    graphics_draw_line(x, y, x + width - 1, y, COLOR_INSET_DARK);
-    graphics_draw_line(x + width - 1, y, x + width - 1, y + height - 1, COLOR_INSET_LIGHT);
-    graphics_draw_line(x, y + height - 1, x + width - 1, y + height - 1, COLOR_INSET_LIGHT);
-    graphics_draw_line(x, y, x, y + height - 1, COLOR_INSET_DARK);
+    graphics_draw_horizontal_line(x, x + width - 1, y, COLOR_INSET_DARK);
+    graphics_draw_vertical_line(x + width - 1, y, y + height - 1, COLOR_INSET_LIGHT);
+    graphics_draw_horizontal_line(x, x + width - 1, y + height - 1, COLOR_INSET_LIGHT);
+    graphics_draw_vertical_line(x, y, y + height - 1, COLOR_INSET_DARK);
 }
 
 void graphics_fill_rect(int x, int y, int width, int height, color_t color)
 {
     for (int yy = y; yy < height + y; yy++) {
-        graphics_draw_line(x, yy, x + width - 1, yy, color);
+        graphics_draw_horizontal_line(x, x + width - 1, yy, color);
     }
 }
 

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -42,9 +42,8 @@ color_t *graphics_get_pixel(int x, int y);
 
 void graphics_clear_screen(void);
 
-void graphics_draw_pixel(int x, int y, color_t color);
-
-void graphics_draw_line(int x1, int y1, int x2, int y2, color_t color);
+void graphics_draw_vertical_line(int x, int y1, int y2, color_t color);
+void graphics_draw_horizontal_line(int x1, int x2, int y, color_t color);
 
 void graphics_draw_rect(int x, int y, int width, int height, color_t color);
 void graphics_draw_inset_rect(int x, int y, int width, int height);

--- a/src/graphics/text.c
+++ b/src/graphics/text.c
@@ -57,18 +57,15 @@ void text_draw_cursor(int x_offset, int y_offset, int is_insert)
     }
     if (input_cursor.visible) {
         if (is_insert) {
-            graphics_draw_line(
-                x_offset + input_cursor.x_offset - 3, y_offset + input_cursor.y_offset - 3,
-                x_offset + input_cursor.x_offset + 1, y_offset + input_cursor.y_offset - 3,
-                COLOR_WHITE);
-            graphics_draw_line(
-                x_offset + input_cursor.x_offset - 1, y_offset + input_cursor.y_offset - 3,
-                x_offset + input_cursor.x_offset - 1, y_offset + input_cursor.y_offset + 13,
-                COLOR_WHITE);
-            graphics_draw_line(
-                x_offset + input_cursor.x_offset - 3, y_offset + input_cursor.y_offset + 14,
-                x_offset + input_cursor.x_offset + 1, y_offset + input_cursor.y_offset + 14,
-                COLOR_WHITE);
+            graphics_draw_horizontal_line(
+                x_offset + input_cursor.x_offset - 3, x_offset + input_cursor.x_offset + 1,
+                y_offset + input_cursor.y_offset - 3, COLOR_WHITE);
+            graphics_draw_vertical_line(
+                x_offset + input_cursor.x_offset - 1,  y_offset + input_cursor.y_offset - 3,
+                y_offset + input_cursor.y_offset + 13, COLOR_WHITE);
+            graphics_draw_horizontal_line(
+                x_offset + input_cursor.x_offset - 3,  x_offset + input_cursor.x_offset + 1,
+                y_offset + input_cursor.y_offset + 14, COLOR_WHITE);
         } else {
             graphics_fill_rect(
                 x_offset + input_cursor.x_offset, y_offset + input_cursor.y_offset + 14,

--- a/src/widget/minimap.c
+++ b/src/widget/minimap.c
@@ -111,7 +111,7 @@ static int draw_figure(int x_view, int y_view, int grid_offset)
     } else if (color_type == FIGURE_COLOR_ENEMY) {
         color = data.enemy_color;
     }
-    graphics_draw_line(x_view, y_view, x_view +1, y_view, color);
+    graphics_draw_horizontal_line(x_view, x_view +1, y_view, color);
     return 1;
 }
 

--- a/src/widget/sidebar.c
+++ b/src/widget/sidebar.c
@@ -138,9 +138,9 @@ static void draw_minimap(int force)
         if (data.minimap_redraw_requested || scroll_in_progress() || force) {
             int x_offset = get_x_offset_expanded();
             widget_minimap_draw(x_offset + 8, 59, 73, 111);
-            graphics_draw_line(x_offset + 7, 58, x_offset + 153, 58, COLOR_MINIMAP_DARK);
-            graphics_draw_line(x_offset + 7, 59, x_offset + 7, 170, COLOR_MINIMAP_DARK);
-            graphics_draw_line(x_offset + 153, 59, x_offset + 153, 170, COLOR_MINIMAP_LIGHT);
+            graphics_draw_horizontal_line(x_offset + 7, x_offset + 153, 58, COLOR_MINIMAP_DARK);
+            graphics_draw_vertical_line(x_offset + 7, 59, 170, COLOR_MINIMAP_DARK);
+            graphics_draw_vertical_line(x_offset + 153, 59, 170, COLOR_MINIMAP_LIGHT);
         }
     }
 }

--- a/src/window/advisor/financial.c
+++ b/src/window/advisor/financial.c
@@ -68,8 +68,8 @@ static int draw_background(void)
     draw_row(60, 9, 170, last_year->income.exports, this_year->income.exports);
     draw_row(60, 20, 185, last_year->income.donated, this_year->income.donated);
 
-    graphics_draw_line(280, 198, 350, 198, COLOR_BLACK);
-    graphics_draw_line(420, 198, 490, 198, COLOR_BLACK);
+    graphics_draw_horizontal_line(280, 350, 198, COLOR_BLACK);
+    graphics_draw_horizontal_line(420, 490, 198, COLOR_BLACK);
     
     draw_row(60, 10, 203, last_year->income.total, this_year->income.total);
 
@@ -88,8 +88,8 @@ static int draw_background(void)
     draw_row(60, 16, 302, last_year->expenses.sundries, this_year->expenses.sundries);
     draw_row(60, 21, 317, last_year->expenses.tribute, this_year->expenses.tribute);
 
-    graphics_draw_line(280, 330, 350, 330, COLOR_BLACK);
-    graphics_draw_line(420, 330, 490, 330, COLOR_BLACK);
+    graphics_draw_horizontal_line(280, 350, 330, COLOR_BLACK);
+    graphics_draw_horizontal_line(420, 490, 330, COLOR_BLACK);
     
     draw_row(60, 17, 335, last_year->expenses.total, this_year->expenses.total);
     draw_row(60, 18, 358, last_year->net_in_out, this_year->net_in_out);

--- a/src/window/advisor/population.c
+++ b/src/window/advisor/population.c
@@ -150,7 +150,7 @@ static void draw_history_graph(int full_size, int x, int y)
                         image_draw(image_group(GROUP_POPULATION_GRAPH_BAR) + 3, x + 2 * m, y + 200 - val);
                         break;
                     default:
-                        graphics_draw_line(x + m, y + 200 - val, x + m, y + 199, COLOR_RED);
+                        graphics_draw_vertical_line(x + m, y + 200 - val, y + 199, COLOR_RED);
                         break;
                 }
             }
@@ -164,7 +164,7 @@ static void draw_history_graph(int full_size, int x, int y)
                 if (max_months == 20) {
                     graphics_fill_rect(x + m, y + 50 - val, 4, val + 1, COLOR_RED);
                 } else {
-                    graphics_draw_line(x + m, y + 50 - val, x + m, y + 50, COLOR_RED);
+                    graphics_draw_vertical_line(x + m, y + 50 - val, y + 50, COLOR_RED);
                 }
             }
         }
@@ -213,7 +213,7 @@ static void draw_census_graph(int full_size, int x, int y)
         for (int i = 0; i < 100; i++) {
             int val = city_population_at_age(i) >> y_shift;
             if (val > 0) {
-                graphics_draw_line(x + i, y + 50 - val, x + i, y + 50, COLOR_RED);
+                graphics_draw_vertical_line(x + i, y + 50 - val, y + 50, COLOR_RED);
             }
         }
     }


### PR DESCRIPTION
Avoid the constant calling of graphics_draw_pixel and draw directly to graphics_canvas.

To prevent clipping errors, clipping for the whole area to be drawn is checked beforehand.

Should marginally improve performance.