### PR TITLE
Cache the minimap to improve performance on window invalidation.

### DIFF
--- a/src/city/view.c
+++ b/src/city/view.c
@@ -3,6 +3,7 @@
 #include "core/direction.h"
 #include "map/grid.h"
 #include "map/image.h"
+#include "widget/sidebar.h"
 
 #define MENUBAR_HEIGHT 24
 
@@ -126,6 +127,7 @@ void city_view_init(void)
 {
     calculate_lookup();
     check_camera_boundaries();
+    widget_sidebar_invalidate_minimap();
 }
 
 int city_view_orientation(void)

--- a/src/graphics/graphics.c
+++ b/src/graphics/graphics.c
@@ -168,14 +168,14 @@ const clip_info *graphics_get_clip_info(int x, int y, int width, int height)
 void graphics_save_to_buffer(int x, int y, int width, int height, color_t *buffer)
 {
     for (int dy = 0; dy < height; dy++) {
-        memcpy(&buffer[dy * height], graphics_get_pixel(x, y + dy), sizeof(color_t) * width);
+        memcpy(&buffer[dy * width], graphics_get_pixel(x, y + dy), sizeof(color_t) * width);
     }
 }
 
 void graphics_draw_from_buffer(int x, int y, int width, int height, const color_t *buffer)
 {
     for (int dy = 0; dy < height; dy++) {
-        memcpy(graphics_get_pixel(x, y + dy), &buffer[dy * height], sizeof(color_t) * width);
+        memcpy(graphics_get_pixel(x, y + dy), &buffer[dy * width], sizeof(color_t) * width);
     }
 }
 

--- a/src/widget/minimap.h
+++ b/src/widget/minimap.h
@@ -3,6 +3,7 @@
 
 #include "input/mouse.h"
 
+void widget_minimap_draw_from_cache(int x_offset, int y_offset, int width_tiles, int height_tiles, int is_scrolling);
 void widget_minimap_draw(int x_offset, int y_offset, int width_tiles, int height_tiles);
 
 int widget_minimap_handle_mouse(const mouse *m);

--- a/src/widget/sidebar.c
+++ b/src/widget/sidebar.c
@@ -137,7 +137,12 @@ static void draw_minimap(int force)
     if (!city_view_is_sidebar_collapsed()) {
         if (data.minimap_redraw_requested || scroll_in_progress() || force) {
             int x_offset = get_x_offset_expanded();
-            widget_minimap_draw(x_offset + 8, 59, 73, 111);
+            if (data.minimap_redraw_requested) {
+                widget_minimap_draw(x_offset + 8, 59, 73, 111);
+                data.minimap_redraw_requested = 0;
+            } else {
+                widget_minimap_draw_from_cache(x_offset + 8, 59, 73, 111, scroll_in_progress());
+            }
             graphics_draw_horizontal_line(x_offset + 7, x_offset + 153, 58, COLOR_MINIMAP_DARK);
             graphics_draw_vertical_line(x_offset + 7, 59, 170, COLOR_MINIMAP_DARK);
             graphics_draw_vertical_line(x_offset + 153, 59, 170, COLOR_MINIMAP_LIGHT);


### PR DESCRIPTION
Should improve tooltip performance.

As a consequence of this change, two bugs were found and fixed.

When the minimap was invalidated (`data.minimap_redraw_requested` set to `1` in `sidebar.c`), it was never set back to `0` so the minimap was being redrawn every single frame. This should improve overall performance.

`graphics_save_to_buffer` and `graphics_draw_from_buffer` were using the height size, and not the width size, to find the starting pixel, which resulted in the wrong pixels being copied if the width and height were different.