### PR TITLE
Implement partial window invalidation based on tooltips.

### DIFF
--- a/src/graphics/tooltip.h
+++ b/src/graphics/tooltip.h
@@ -21,6 +21,7 @@ typedef struct {
     int numeric_prefix;
 } tooltip_context;
 
+void tooltip_invalidate(void);
 void tooltip_handle(const mouse *m, void (*func)(tooltip_context *));
 
 #endif // GRAPHICS_TOOLTIP_H

--- a/src/graphics/window.c
+++ b/src/graphics/window.c
@@ -100,6 +100,7 @@ void window_draw(int force)
 {
     update_mouse_before();
     if (force || refresh_on_draw) {
+        tooltip_invalidate();
         current_window->draw_background();
         refresh_on_draw = 0;
         refresh_immediate = 0;


### PR DESCRIPTION
Massively improves performance when a tooltip is showing as it no longer requires a window to constantly redraw.

Requires the changes in `graphics/graphics.c` from #101 to work properly.