### PR TITLE
Touch support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ set(PLATFORM_FILES
     ${PROJECT_SOURCE_DIR}/src/platform/log.c
     ${PROJECT_SOURCE_DIR}/src/platform/prefs.c
     ${PROJECT_SOURCE_DIR}/src/platform/sound_device.c
+    ${PROJECT_SOURCE_DIR}/src/platform/touch.c
 )
 
 if (VITA_BUILD)
@@ -321,6 +322,7 @@ set(INPUT_FILES
     ${PROJECT_SOURCE_DIR}/src/input/keyboard.c
     ${PROJECT_SOURCE_DIR}/src/input/mouse.c
     ${PROJECT_SOURCE_DIR}/src/input/scroll.c
+    ${PROJECT_SOURCE_DIR}/src/input/touch.c
 )
 set(MAP_FILES
     ${PROJECT_SOURCE_DIR}/src/map/aqueduct.c
@@ -673,6 +675,9 @@ elseif(SWITCH_BUILD)
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 else()
+    if (UNIX AND NOT APPLE AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang"))
+        target_link_libraries(${SHORT_NAME} m)
+    endif()
     target_link_libraries (${SHORT_NAME} ${SDL2_LIBRARY} ${SDL2_MIXER_LIBRARY})
     if(NOT APPLE)
         install(TARGETS ${SHORT_NAME} RUNTIME DESTINATION bin)

--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -505,6 +505,32 @@ void building_construction_start(int x, int y, int grid_offset)
     }
 }
 
+int building_construction_is_updatable(void)
+{
+    switch (data.type) {
+        case BUILDING_CLEAR_LAND:
+        case BUILDING_ROAD:
+        case BUILDING_AQUEDUCT:
+        case BUILDING_DRAGGABLE_RESERVOIR:
+        case BUILDING_WALL:
+        case BUILDING_PLAZA:
+        case BUILDING_GARDENS:
+        case BUILDING_HOUSE_VACANT_LOT:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+void building_construction_cancel(void)
+{
+    map_property_clear_constructing_and_deleted();
+    if (building_construction_is_updatable()) {
+        game_undo_restore_map(1);
+    }
+    data.in_progress = 0;
+}
+
 void building_construction_update(int x, int y, int grid_offset)
 {
     building_type type = data.type;

--- a/src/building/construction.h
+++ b/src/building/construction.h
@@ -15,6 +15,10 @@ int building_construction_in_progress(void);
 
 void building_construction_start(int x, int y, int grid_offset);
 
+int building_construction_is_updatable(void);
+
+void building_construction_cancel(void);
+
 void building_construction_update(int x, int y, int grid_offset);
 
 void building_construction_place(void);

--- a/src/city/view.c
+++ b/src/city/view.c
@@ -220,7 +220,7 @@ void city_view_get_selected_tile_pixels(int *x_pixels, int *y_pixels)
     *y_pixels = data.selected_tile.y_pixels;
 }
 
-int city_view_pixels_to_grid_offset(int x_pixels, int y_pixels)
+int city_view_pixels_to_view_tile(int x_pixels, int y_pixels, view_tile *tile)
 {
     if (x_pixels < data.viewport.x ||
             x_pixels >= data.viewport.x + data.viewport.width_pixels ||
@@ -255,9 +255,19 @@ int city_view_pixels_to_grid_offset(int x_pixels, int y_pixels)
         data.selected_tile.x_pixels -= 30;
     }
     data.selected_tile.y_pixels = data.viewport.y + 15 * y_view_offset - 15; // TODO why -1?
-    int x_view = data.camera.x + x_view_offset;
-    int y_view = data.camera.y + y_view_offset;
-    int grid_offset = view_to_grid_offset_lookup[x_view][y_view];
+
+    tile->x = data.camera.x + x_view_offset;
+    tile->y = data.camera.y + y_view_offset;
+    return 1;
+}
+
+int city_view_pixels_to_grid_offset(int x_pixels, int y_pixels)
+{
+    view_tile view;
+    if (!city_view_pixels_to_view_tile(x_pixels, y_pixels, &view)) {
+        return 0;
+    }
+    int grid_offset = view_to_grid_offset_lookup[view.x][view.y];
     return grid_offset < 0 ? 0 : grid_offset;
 }
 

--- a/src/city/view.h
+++ b/src/city/view.h
@@ -7,6 +7,11 @@
 #define VIEW_X_MAX 165
 #define VIEW_Y_MAX 325
 
+typedef struct {
+    int x;
+    int y;
+} view_tile;
+
 typedef void (map_callback)(int x, int y, int grid_offset);
 
 void city_view_init(void);
@@ -26,6 +31,8 @@ int city_view_to_grid_offset(int x_view, int y_view);
 void city_view_grid_offset_to_xy_view(int grid_offset, int *x_view, int *y_view);
 
 void city_view_get_selected_tile_pixels(int *x_pixels, int *y_pixels);
+
+int city_view_pixels_to_view_tile(int x_pixels, int y_pixels, view_tile *tile);
 
 int city_view_pixels_to_grid_offset(int x_pixels, int y_pixels);
 

--- a/src/empire/empire.c
+++ b/src/empire/empire.c
@@ -82,16 +82,29 @@ void empire_set_viewport(int width, int height)
     check_scroll_boundaries();
 }
 
+void empire_get_scroll(int *x_scroll, int *y_scroll)
+{
+    *x_scroll = data.scroll_x;
+    *y_scroll = data.scroll_y;
+}
+
 void empire_adjust_scroll(int *x_offset, int *y_offset)
 {
     *x_offset = *x_offset - data.scroll_x;
     *y_offset = *y_offset - data.scroll_y;
 }
 
-void empire_scroll_map(int direction)
+void empire_set_scroll(int x, int y)
+{
+    data.scroll_x = x;
+    data.scroll_y = y;
+    check_scroll_boundaries();
+}
+
+int empire_scroll_map(int direction)
 {
     if (direction == DIR_8_NONE) {
-        return;
+        return 0;
     }
     switch (direction) {
         case DIR_0_TOP:
@@ -124,6 +137,7 @@ void empire_scroll_map(int direction)
             break;
     }
     check_scroll_boundaries();
+    return 1;
 }
 
 int empire_selected_object(void)

--- a/src/empire/empire.h
+++ b/src/empire/empire.h
@@ -5,8 +5,10 @@
 
 void empire_load(int is_custom_scenario, int empire_id);
 void empire_init_scenario(void);
-void empire_scroll_map(int direction);
+int empire_scroll_map(int direction);
 void empire_set_viewport(int width, int height);
+void empire_get_scroll(int *x_scroll, int *y_scroll);
+void empire_set_scroll(int x, int y);
 void empire_adjust_scroll(int *x_offset, int *y_offset);
 
 int empire_selected_object(void);

--- a/src/graphics/arrow_button.c
+++ b/src/graphics/arrow_button.c
@@ -9,6 +9,9 @@ static const int REPEATS[] = {
     1, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0
 };
 
+static const time_millis REPEAT_MILLIS = 30;
+static const unsigned int BUTTON_PRESSED_FRAMES = 3;
+
 void arrow_buttons_draw(int x, int y, arrow_button *buttons, int num_buttons)
 {
     for (int i = 0; i < num_buttons; i++) {
@@ -39,7 +42,7 @@ int arrow_buttons_handle_mouse(const mouse *m, int x, int y, arrow_button *butto
 
     time_millis curr_time = time_get_millis();
     int should_repeat = 0;
-    if (curr_time - last_time >= 30) {
+    if (curr_time - last_time >= REPEAT_MILLIS) {
         should_repeat = 1;
         last_time = curr_time;
     }
@@ -60,13 +63,13 @@ int arrow_buttons_handle_mouse(const mouse *m, int x, int y, arrow_button *butto
     }
     arrow_button *btn = &buttons[button_id -1];
     if (m->left.went_down) {
-        btn->pressed = 3;
+        btn->pressed = BUTTON_PRESSED_FRAMES;
         btn->repeats = 0;
         btn->left_click_handler(btn->parameter1, btn->parameter2);
         return button_id;
     }
     if (m->left.is_down) {
-        btn->pressed = 3;
+        btn->pressed = BUTTON_PRESSED_FRAMES;
         if (should_repeat) {
             btn->repeats++;
             if (btn->repeats < 48) {

--- a/src/graphics/generic_button.c
+++ b/src/graphics/generic_button.c
@@ -24,7 +24,7 @@ int generic_buttons_handle_mouse(const mouse *m, int x, int y, generic_button *b
         return 0;
     }
     generic_button *button = &buttons[button_id -1];
-    if (button->button_type == GB_IMMEDIATE) {
+    if (button->button_type == GB_IMMEDIATE && !m->is_touch) {
         if (m->left.went_down) {
             button->left_click_handler(button->parameter1, button->parameter2);
         } else if (m->right.went_down) {
@@ -32,7 +32,7 @@ int generic_buttons_handle_mouse(const mouse *m, int x, int y, generic_button *b
         } else {
             return 0;
         }
-    } else if (button->button_type == GB_ON_MOUSE_UP) {
+    } else if (button->button_type == GB_ON_MOUSE_UP || m->is_touch) {
         if (m->left.went_up) {
             button->left_click_handler(button->parameter1, button->parameter2);
         } else if (m->right.went_up) {

--- a/src/graphics/image_button.c
+++ b/src/graphics/image_button.c
@@ -82,16 +82,17 @@ int image_buttons_handle_mouse(const mouse *m, int x, int y, image_button *butto
     if (!hit_button) {
         return 0;
     }
+    int left_button_pressed = (!m->is_touch && m->left.went_down) || (m->is_touch && m->left.went_up);
     if (hit_button->button_type == IB_SCROLL) {
         if (!m->left.went_down && !m->left.is_down) {
             return 0;
         }
     } else if (hit_button->button_type == IB_BUILD || hit_button->button_type == IB_NORMAL) {
-        if (!m->left.went_down && !m->right.went_down) {
+        if (!left_button_pressed && !m->right.went_down) {
             return 0;
         }
     }
-    if (m->left.went_down) {
+    if (left_button_pressed) {
         sound_effect_play(SOUND_EFFECT_ICON);
         hit_button->pressed = 1;
         hit_button->pressed_since = time_get_millis();

--- a/src/graphics/tooltip.c
+++ b/src/graphics/tooltip.c
@@ -16,7 +16,8 @@
 
 #include <stdlib.h>
 
-#define DEFAULT_TEXT_GROUP 68
+static const int DEFAULT_TEXT_GROUP = 68;
+static const time_millis TOOLTIP_DELAY_MILLIS = 150;
 
 static time_millis last_update = 0;
 static uint8_t overlay_string[1000];
@@ -45,7 +46,7 @@ static int should_draw_tooltip(tooltip_context* c)
         reset_timer();
         return 0;
     }
-    if (time_get_millis() - last_update < 150) { // delay drawing by 150 ms
+    if (time_get_millis() - last_update < TOOLTIP_DELAY_MILLIS) { // delay drawing tooltip
         return 0;
     }
     return 1;
@@ -250,6 +251,10 @@ void tooltip_invalidate(void)
 
 void tooltip_handle(const mouse *m, void (*func)(tooltip_context *))
 {
+    if (m->is_touch && !m->left.is_down) {
+        reset_timer();
+        return;
+    }
     tooltip_context context = {m->x, m->y, 0, 0, 0, 0, 0, 0};
     context.text_group = DEFAULT_TEXT_GROUP;
     if (setting_tooltips() && func) {

--- a/src/graphics/window.c
+++ b/src/graphics/window.c
@@ -2,6 +2,7 @@
 
 #include "graphics/warning.h"
 #include "input/cursor.h"
+#include "input/touch.h"
 #include "window/city.h"
 
 #define MAX_QUEUE 3
@@ -87,12 +88,15 @@ void window_go_back(void)
 
 static void update_mouse_before(void)
 {
-    mouse_determine_button_state();
+    if (!touch_to_mouse()) {
+        mouse_determine_button_state();  // touch overrides mouse
+    }
 }
 
 static void update_mouse_after(void)
 {
-    mouse_set_scroll(SCROLL_NONE);
+    reset_touches();
+    mouse_reset_scroll();
     input_cursor_update(current_window->id);
 }
 

--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -16,25 +16,62 @@ const mouse *mouse_get(void)
     return &data;
 }
 
+void mouse_set_from_touch(const touch *first, const touch *last)
+{
+    data.x = first->current_point.x;
+    data.y = first->current_point.y;
+    data.scrolled = touch_get_scroll();
+    data.is_inside_window = !first->has_ended;
+    data.is_touch = 1;
+
+    data.left.system_change = SYSTEM_NONE;
+    data.right.system_change = SYSTEM_NONE;
+
+    if (!touch_is_scroll()) {
+        data.left.is_down = (!first->has_ended && first->in_use);
+        data.left.went_down = first->has_started;
+        data.left.went_up = first->has_ended;
+
+        data.right.is_down = (!last->has_ended && last->in_use);
+        data.right.went_down = last->has_started;
+        data.right.went_up = last->has_ended;
+    } else {
+        data.left.is_down = 0;
+        data.left.went_down = 0;
+        data.left.went_up = 0;
+
+        data.right.is_down = 0;
+        data.right.went_down = 0;
+        data.right.went_up = 0;
+    }
+}
+
 void mouse_set_position(int x, int y)
 {
     data.x = x;
     data.y = y;
+    data.is_touch = 0;
+    data.is_inside_window = 1;
 }
 
 void mouse_set_left_down(int down)
 {
     data.left.system_change |= down ? SYSTEM_DOWN : SYSTEM_UP;
+    data.is_touch = 0;
+    data.is_inside_window = 1;
 }
 
 void mouse_set_right_down(int down)
 {
     data.right.system_change |= down ? SYSTEM_DOWN : SYSTEM_UP;
+    data.is_touch = 0;
+    data.is_inside_window = 1;
 }
 
 void mouse_set_inside_window(int inside)
 {
     data.is_inside_window = inside;
+    data.is_touch = 0;
 }
 
 static void update_button_state(mouse_button *button)
@@ -54,6 +91,13 @@ void mouse_determine_button_state(void)
 void mouse_set_scroll(scroll_state state)
 {
     data.scrolled = state;
+    data.is_touch = 0;
+    data.is_inside_window = 1;
+}
+
+void mouse_reset_scroll(void)
+{
+    data.scrolled = SCROLL_NONE;
 }
 
 void mouse_reset_up_state(void)
@@ -62,12 +106,26 @@ void mouse_reset_up_state(void)
     data.right.went_up = 0;
 }
 
+void mouse_reset_button_state(void)
+{
+    data.left.is_down = 0;
+    data.left.went_down = 0;
+    data.left.went_up = 0;
+    data.left.system_change = SYSTEM_NONE;
+
+    data.right.is_down = 0;
+    data.right.went_down = 0;
+    data.right.went_up = 0;
+    data.right.system_change = SYSTEM_NONE;
+}
+
 const mouse *mouse_in_dialog(const mouse *m)
 {
     dialog.left = m->left;
     dialog.right = m->right;
     dialog.scrolled = m->scrolled;
     dialog.is_inside_window = m->is_inside_window;
+    dialog.is_touch = m->is_touch;
 
     dialog.x = m->x - screen_dialog_offset_x();
     dialog.y = m->y - screen_dialog_offset_y();

--- a/src/input/mouse.h
+++ b/src/input/mouse.h
@@ -6,6 +6,8 @@
  * Mouse state
  */
 
+#include "input/touch.h"
+
 /**
  * Mouse button state
  */
@@ -32,6 +34,7 @@ typedef struct {
     mouse_button left; /**< Left mouse button */
     mouse_button right; /**< Right mouse button */
     int is_inside_window; /**< Whether the mouse is in the window */
+    int is_touch; /**< Whether the mouse is a translated touch event */
 } mouse;
 
 /**
@@ -55,7 +58,18 @@ void mouse_set_scroll(scroll_state state);
 
 void mouse_set_inside_window(int inside);
 
+/**
+ * Changes the mouse information from touch information
+ * @param first The first touch
+ * @param last The last touch
+ */
+void mouse_set_from_touch(const touch *first, const touch *last);
+
 void mouse_reset_up_state(void);
+
+void mouse_reset_scroll(void);
+
+void mouse_reset_button_state(void);
 
 void mouse_determine_button_state(void);
 

--- a/src/input/scroll.h
+++ b/src/input/scroll.h
@@ -1,11 +1,22 @@
 #ifndef INPUT_SCROLL_H
 #define INPUT_SCROLL_H
 
+#include "city/view.h"
 #include "input/mouse.h"
+#include "input/touch.h"
 
 int scroll_in_progress(void);
 
 int scroll_get_direction(const mouse *m);
+
+void scroll_set_custom_margins(int x, int y, int width, int height);
+void scroll_restore_margins(void);
+
+void scroll_start_touch_drag(const view_tile *position, touch_coords coords);
+int scroll_move_touch_drag(int original_x, int original_y, int current_x, int current_y, view_tile *position);
+void scroll_end_touch_drag(void);
+int scroll_decay(view_tile *position);
+touch_coords scroll_get_original_touch_position(void);
 
 void scroll_arrow_left(void);
 void scroll_arrow_right(void);

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -1,0 +1,198 @@
+#include "input/touch.h"
+
+#include "input/mouse.h"
+
+#include <stdlib.h>
+
+static touch touch_data[MAX_ACTIVE_TOUCHES + 1];
+static touch old_touch;
+static int last_scroll_position;
+static const time_millis CLICK_TIME = 300;
+static const int NOT_MOVING_RANGE = 5;
+static const int SCROLL_FINGER_RADIUS = 25;
+
+static int start_delayed(const touch *t)
+{
+    return (t->has_started && !t->has_moved && !t->has_ended && ((time_get_millis() - t->start_time) < (time_millis) (CLICK_TIME / 2)));
+}
+
+const touch *get_earliest_touch(void)
+{
+    time_millis timestamp = -1;
+    int touch_index = MAX_ACTIVE_TOUCHES;
+    for (int i = 0; i < MAX_ACTIVE_TOUCHES; ++i) {
+        if (touch_data[i].in_use && !start_delayed(&touch_data[i]) && touch_data[i].start_time < timestamp) {
+            timestamp = touch_data[i].start_time;
+            touch_index = i;
+        }
+    }
+    return &touch_data[touch_index];
+}
+
+const touch *get_latest_touch(void)
+{
+    int active_touches = 0;
+    time_millis timestamp = 0;
+    int touch_index = MAX_ACTIVE_TOUCHES;
+    for (int i = 0; i < MAX_ACTIVE_TOUCHES; ++i) {
+        if (touch_data[i].in_use && !start_delayed(&touch_data[i])) {
+            ++active_touches;
+            if (touch_data[i].start_time > timestamp) {
+                timestamp = touch_data[i].start_time;
+                touch_index = i;
+            }
+        }
+    }
+    return (active_touches > 1) ? &touch_data[touch_index] : &touch_data[MAX_ACTIVE_TOUCHES];
+}
+
+int get_total_active_touches(void)
+{
+    int active_touches = 0;
+    for (int i = 0; i < MAX_ACTIVE_TOUCHES; ++i) {
+        if (touch_data[i].in_use) {
+            ++active_touches;
+        }
+    }
+    return active_touches;
+}
+
+int touch_not_click(const touch *t)
+{
+    return (t->has_moved || (!t->has_ended && (time_get_millis() - t->start_time) >= CLICK_TIME) ||
+        (t->has_ended && (t->last_change_time - t->start_time) >= CLICK_TIME));
+}
+
+int touch_was_click(const touch *t)
+{
+    return (t->has_ended && !t->has_moved && (t->last_change_time - t->start_time) < CLICK_TIME);
+}
+
+int touch_was_double_click(const touch *t)
+{
+    return (touch_was_click(t) && touch_was_click(&old_touch) &&
+        (t->start_time > old_touch.last_change_time) &&
+        (t->start_time - old_touch.last_change_time) < CLICK_TIME);
+}
+
+int touch_is_scroll(void)
+{
+    if (touch_data[0].in_use && touch_data[1].in_use) {
+        int first = 0;
+        int last = 1;
+        if (touch_data[0].start_time > touch_data[1].start_time) {
+            first = 1;
+            last = 0;
+        }
+        return (((touch_data[last].start_time - touch_data[first].start_time) < CLICK_TIME) && !touch_was_click(get_latest_touch()));
+    }
+    const touch *result = get_earliest_touch();
+    return (result->in_use && start_delayed(result));
+}
+
+int touch_get_scroll(void)
+{
+    if (!touch_is_scroll() || !touch_data[0].has_moved || !touch_data[1].has_moved) {
+        return SCROLL_NONE;
+    }
+    if (!last_scroll_position) {
+        last_scroll_position = touch_data[0].start_point.y;
+    }
+    int delta_x = abs((touch_data[0].current_point.x - touch_data[0].start_point.x) - (touch_data[1].current_point.x - touch_data[1].start_point.x));
+    int delta_y = abs((touch_data[0].current_point.y - touch_data[0].start_point.y) - (touch_data[1].current_point.y - touch_data[1].start_point.y));
+    if (delta_x > SCROLL_FINGER_RADIUS || delta_y > SCROLL_FINGER_RADIUS) {
+        return SCROLL_NONE;
+    }
+    int delta = touch_data[0].current_point.y - last_scroll_position;
+    if (abs(delta) < NOT_MOVING_RANGE * 2) {
+        return SCROLL_NONE;
+    }
+    last_scroll_position = touch_data[0].current_point.y;
+    return (delta > 0) ? SCROLL_UP : SCROLL_DOWN;
+}
+
+static int get_unused_touch_index(void)
+{
+    int i = 0;
+    while (i < MAX_ACTIVE_TOUCHES) {
+        if (!touch_data[i].in_use) {
+            break;
+        }
+        ++i;
+    }
+    return i;
+}
+
+int touch_create(touch_coords start_coords, time_millis start_time)
+{
+    int index = get_unused_touch_index();
+    if (index != MAX_ACTIVE_TOUCHES) {
+        touch *t = &touch_data[index];
+        t->in_use = 1;
+        t->has_started = 1;
+        t->has_ended = 0;
+        t->start_point = start_coords;
+        t->current_point = start_coords;
+        t->frame_movement.x = 0;
+        t->frame_movement.y = 0;
+        t->speed.x = 0;
+        t->speed.y = 0;
+        t->start_time = start_time;
+        t->last_change_time = start_time;
+    }
+    return index;
+}
+
+void touch_update(int index, touch_coords current_coords, touch_coords frame_movement, time_millis current_time, int has_ended)
+{
+    if (index < 0 || index >= MAX_ACTIVE_TOUCHES || !touch_data[index].in_use) {
+        return;
+    }
+    touch *t = &touch_data[index];
+    t->current_point = current_coords;
+    t->frame_movement.x += frame_movement.x;
+    t->frame_movement.y += frame_movement.y;
+    t->last_change_time = current_time;
+    t->has_ended = has_ended;
+
+    if ((abs(current_coords.x - t->start_point.x) > NOT_MOVING_RANGE) || (abs(current_coords.y - t->start_point.y) > NOT_MOVING_RANGE)) {
+        t->has_moved = 1;
+    }
+}
+
+void reset_touches(void)
+{
+    for (int i = 0; i < MAX_ACTIVE_TOUCHES; ++i) {
+        touch *t = &touch_data[i];
+        if (!t->in_use) {
+            continue;
+        }
+        if (t->has_ended) {
+            t->in_use = 0;
+            old_touch = *t;
+            t->has_started = 0;
+            t->has_moved = 0;
+            t->has_ended = 0;
+            last_scroll_position = 0;
+            continue;
+        }
+        t->has_started = start_delayed(t);
+        t->frame_movement.x = 0;
+        t->frame_movement.y = 0;
+    }
+}
+
+int touch_to_mouse(void)
+{
+    const touch *first = get_earliest_touch();
+    if (!first->in_use) {
+        if (mouse_get()->is_touch) {
+            mouse_reset_scroll();
+            mouse_reset_button_state();
+            return 1;
+        }
+        return 0;
+    }
+    mouse_set_from_touch(first, get_latest_touch());
+    return 1;
+}

--- a/src/input/touch.h
+++ b/src/input/touch.h
@@ -1,0 +1,49 @@
+#ifndef INPUT_TOUCH_H
+#define INPUT_TOUCH_H
+
+#include "core/time.h"
+
+#define MAX_ACTIVE_TOUCHES 2
+
+typedef struct {
+    int x;
+    int y;
+} touch_coords;
+
+typedef struct {
+    float x;
+    float y;
+} touch_speed;
+
+typedef struct {
+    int in_use;
+    int has_started;
+    int has_moved;
+    int has_ended;
+    touch_coords start_point;
+    touch_coords current_point;
+    touch_coords frame_movement;
+    touch_speed speed;
+    time_millis start_time;
+    time_millis last_change_time;
+} touch;
+
+const touch *get_earliest_touch(void);
+const touch *get_latest_touch(void);
+int get_total_active_touches(void);
+
+int touch_not_click(const touch *t);
+int touch_was_click(const touch *t);
+int touch_was_double_click(const touch *t);
+
+int touch_is_scroll(void);
+int touch_get_scroll(void);
+
+void reset_touches(void);
+
+int touch_create(touch_coords start_coords, time_millis start_time);
+void touch_update(int index, touch_coords current_coords, touch_coords frame_movement, time_millis current_time, int has_ended);
+
+int touch_to_mouse(void);
+
+#endif // INPUT_TOUCH_H

--- a/src/platform/touch.c
+++ b/src/platform/touch.c
@@ -1,0 +1,52 @@
+#include "platform/touch.h"
+
+#include "core/time.h"
+#include "game/settings.h"
+#include "graphics/screen.h"
+#include "input/touch.h"
+
+static SDL_FingerID touch_id[MAX_ACTIVE_TOUCHES];
+
+#ifdef __APPLE__
+static SDL_TouchID trackpad_id;
+#endif
+
+static touch_coords get_touch_coordinates(float x, float y)
+{
+    touch_coords coords;
+    coords.x = (int)(x * screen_width());
+    coords.y = (int)(y * screen_height());
+    return coords;
+}
+
+static int get_touch_index(SDL_FingerID id)
+{
+    for (int i = 0; i < MAX_ACTIVE_TOUCHES; ++i) {
+        if (touch_id[i] == id) {
+            return i;
+        }
+    }
+    return MAX_ACTIVE_TOUCHES;
+}
+
+void platform_touch_start(SDL_TouchFingerEvent *event)
+{
+#ifdef __APPLE__
+    // Attempt to disable trackpad touches on MacOS
+    if (!trackpad_id) {
+        trackpad_id = SDL_GetTouchDevice(0);
+    }
+    if (event->touchId == trackpad_id) {
+        return;
+    }
+#endif
+    int index = touch_create(get_touch_coordinates(event->x, event->y), event->timestamp);
+    if (index != MAX_ACTIVE_TOUCHES) {
+        touch_id[index] = event->fingerId;
+    }
+}
+
+void platform_touch_update(SDL_TouchFingerEvent *event, int has_ended)
+{
+    touch_update(get_touch_index(event->fingerId), get_touch_coordinates(event->x, event->y), get_touch_coordinates(event->dx, event->dy), event->timestamp, has_ended);
+}

--- a/src/platform/touch.h
+++ b/src/platform/touch.h
@@ -1,0 +1,9 @@
+#ifndef PLATFORM_TOUCH_H
+#define PLATFORM_TOUCH_H
+
+#include "SDL.h"
+
+void platform_touch_start(SDL_TouchFingerEvent *event);
+void platform_touch_update(SDL_TouchFingerEvent *event, int has_ended);
+
+#endif // PLATFORM_TOUCH_H

--- a/src/widget/city.h
+++ b/src/widget/city.h
@@ -14,6 +14,7 @@ void widget_city_draw_for_figure(int figure_id, pixel_coordinate *coord);
 
 void widget_city_draw_construction_cost(void);
 
+int widget_city_has_input(void);
 void widget_city_handle_mouse(const mouse *m);
 void widget_city_handle_mouse_military(const mouse *m, int legion_formation_id);
 

--- a/src/widget/sidebar.c
+++ b/src/widget/sidebar.c
@@ -19,6 +19,7 @@
 #include "map/orientation.h"
 #include "scenario/property.h"
 #include "sound/effect.h"
+#include "widget/city.h"
 #include "widget/minimap.h"
 #include "window/advisors.h"
 #include "window/build_menu.h"
@@ -302,6 +303,9 @@ void widget_sidebar_draw_foreground_military(void)
 
 int widget_sidebar_handle_mouse(const mouse *m)
 {
+    if (widget_city_has_input()) {
+        return 0;
+    }
     int click = 0;
     int button_id;
     data.focus_button_for_tooltip = 0;

--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -16,6 +16,7 @@
 #include "graphics/text.h"
 #include "graphics/window.h"
 #include "scenario/property.h"
+#include "widget/city.h"
 #include "window/advisors.h"
 #include "window/city.h"
 #include "window/difficulty_options.h"
@@ -334,6 +335,9 @@ static int handle_mouse_menu(const mouse *m)
 
 int widget_top_menu_handle_mouse(const mouse *m)
 {
+    if (widget_city_has_input()) {
+        return 0;
+    }
     if (data.open_sub_menu) {
         return handle_mouse_submenu(m);
     } else {


### PR DESCRIPTION
This is a touch support branch.

It is feature-complete, but it may still have bugs.

### 1. Touch usage:

A single finger is equivalent to mouse usage in most menus. You can tap any menu with one finger and it will  behave as a left mouse click.

- Touch actions override mouse actions. If you are touching the screen and moving the mouse, the mouse cursor will not move.
- In the city window, if nothing is being built, you can drag the finger to scroll the map. This also works for the empire view.
- When building something, there are two types of buildings with different behaviors: normal buildings such as schools and prefectures, and special buildings like roads, aqueducts, gardens, plazas, walls, houses and the clear tool. These buildings are special because then can be dragged to place multiple copies of them.
- If a single building is being built, you can drag the finger to show the shadow of the building's construction. Releasing the finger will place the building at the desired location. To cancel building construction, tap anywhere on the map with a second finger. To scroll the map when attempting to build something, get close to the city edges (NOT the window edges).
- If a road, houses, walls, gardens, plazas, reservoirs are being built or land is being cleared, you can select and drag that building with a finger. Releasing the finger creates the buildings in the selected area. The map can be scrolled the same way as when building a normal building. To cancel this build, tap once with a second finger. To restart the build after cancelling it, release and hold the first finger in the desired spot.
- If a legion is selected, you can scroll the map by touching and dragging a finger like you would if no construction was active. However, if you tap anywhere on the map, the legion will move there/attack. To not use the legion, press and hold with a finger and thap anywhere on the map with another finger. Please note that as of now there is no visual feedback when a legion is selected, as the only feedback on the original C3 was the mouse cursor, which for obvious reasons doesn't appear when using touch.
- To view a building information, make sure no construction is active. Place a finger in the tile you want to inspect, and tap anywhere in the city with the second finger.
-  To right-click in a menu, tap with two fingers. For better control you can press and hold with the first finger on the position to right-click, and then tap anywhere with a second finger.
- To view tooltips, touch and hold where you want to check.
- You can scroll text or the file dialog windows by touching and dragging up/down with two fingers at the same time.

### 2. Pending changes:

- [x] Empire map scrolling.
- [x] Right click emulation.
- [x] Scrolling the map during a build when reaching the map edges (*not* the window edges as when using the mouse). The closer to the map edge, the faster the scroll (maximum speed will be the scroll speed set in the settings).
- [x] Scroll decay when touch scrolling the map.
- [x] Mouse wheel emulation.
- [x] Improve military touch handling.

### 3. Technical stuff:

- This code makes heavy usage of the recently created `map_point` structure. I'm not sure I'm using it properly, but it gets the job done and reduces the number of function parameters.
- The `touch` structure is being passed by value. It was a small `struct` when I started, but it's getting bigger fast. I still like to directly copy it by value, but if it gets too big or if you think it's better, I'll start using `const touch *`.
- This code makes it possible to cancel a pending construction such as a row of houses or a road. That feature does not exist Caesar 3, but then again the game doesn't have touch support! However if you want it is now easy to add a "cancel construction" feature by right-clicking with the mouse if that feels appropriate.
- Given how the code evolved, it is now possible to merge `touch` and `mouse` structure to a single `pointer_input` structure (the name may be subject to change, maybe `pointing_device`?). Here is how I would suggest such a merge:
To distinguish between touch and mouse events, a `pointer_input` struct member named `is_touch` would be used.
Mouse buttons `left` and `right` would be replaced with the names `first` (representing the left button or the first active touch) and `second` (representing the right button or the second active touch) respectively. `went_down`, `is_down` and `went_up` would be replaced with `was_pressed`, `is_pressed` and `was_released`.
Mouse event handling would be changed to provide as much information to the `pointer_input` structure as the `touch` struct currently does.
Meta-information would be available via the functions `pointer_input_was_tap(button)`, `pointer_input_was_double_tap(button)` and `pointer_input_was_drag(button)`.
All current references to `mouse` would be changed to `pointer_input`. For example, `const mouse *m = mouse_get()` would become `const pointer_input *p = pointer_input_get()`.
And more things I as I remember or find useful.
I'll probably do this in a separate PR, as the necessary code changes will be substancial.

### 4. Suggestions?

- Even though using military units works, right now there is no visual feedback to show whether a legion is selected or not as there is no mouse cursor when touch is used. What could be a good replacement?
- The same problem exists with the clear tool. That may be fixed by some solution from #103 though.

Apart from bugfixing and code improvements, this is ready for merging after rebasing everything to a single commit.

Suggestions are still welcome!