### PR TITLE
updated CMakeLists.txt for macOS bundle creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ doc
 .vs
 src/platform/version.h
 res/version.rc
+res/julius.icns
 /CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,11 @@ set(WINDOW_FILES
     ${PROJECT_SOURCE_DIR}/src/window/victory_video.c
 )
 
+set(MACOSX_FILES "")
+if(APPLE)
+    set(MACOSX_FILES ${PROJECT_SOURCE_DIR}/res/julius.icns)
+endif()
+
 add_executable(julius
     WIN32
     ${PLATFORM_FILES}
@@ -423,6 +428,7 @@ add_executable(julius
     ${WINDOW_FILES}
     ${SMK_FILES}
     ${PROJECT_SOURCE_DIR}/res/julius.rc
+    ${MACOSX_FILES}
 )
 
 find_package(SDL2 REQUIRED)
@@ -430,6 +436,45 @@ find_package(SDL2_mixer REQUIRED)
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+endif()
+
+if(APPLE)
+    # generating a macOS icns file (see https://stackoverflow.com/a/20703594)
+    add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/res/julius.icns
+        COMMAND mkdir -p julius.iconset
+        COMMAND sips -z 16 16    julius_256.png --out julius.iconset/icon_16x16.png
+        COMMAND sips -z 32 32    julius_256.png --out julius.iconset/icon_16x16@2x.png
+        COMMAND sips -z 32 32    julius_256.png --out julius.iconset/icon_32x32.png
+        COMMAND sips -z 64 64    julius_256.png --out julius.iconset/icon_32x32@2x.png
+        COMMAND sips -z 128 128  julius_256.png --out julius.iconset/icon_128x128.png
+        COMMAND sips -z 256 256  julius_256.png --out julius.iconset/icon_128x128@2x.png
+        COMMAND sips -z 256 256  julius_256.png --out julius.iconset/icon_256x256.png
+        COMMAND iconutil -c icns julius.iconset
+        COMMAND rm -R julius.iconset
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/res)
+    set_source_files_properties(${PROJECT_SOURCE_DIR}/res/julius.icns PROPERTIES
+        MACOSX_PACKAGE_LOCATION "Resources")
+
+    # setting variables that will populate Info.plist
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.bvschaik.julius")
+    set(MACOSX_BUNDLE_BUNDLE_NAME ${PROJECT_NAME})
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.10" CACHE STRING "Minimum OS X deployment version" FORCE)
+    set(MACOSX_BUNDLE_ICON_FILE "julius.icns")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION
+        "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}${VERSION_REVISION}")
+    set(MACOSX_BUNDLE_LONG_VERSION_STRING ${MACOSX_BUNDLE_BUNDLE_VERSION})
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${MACOSX_BUNDLE_BUNDLE_VERSION})
+
+    set_target_properties(julius PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST "${PROJECT_SOURCE_DIR}/res/Info.plist.in")
+
+    # when installing, "fixup" automatically copies librairies inside the
+    # bundle and links the binary against them
+    install(CODE "
+        include(BundleUtilities)
+        fixup_bundle(${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app \"\" \"\")
+    ")
 endif()
 
 include_directories(${SDL2_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,12 +469,20 @@ if(APPLE)
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_INFO_PLIST "${PROJECT_SOURCE_DIR}/res/Info.plist.in")
 
+    set(DIRS "")
+
+    # if SDL2_mixer library is a framework, we need to indicate to CMake
+    # the path to its dependencies (Ogg.framework etc):
+    if(EXISTS "${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
+        set(DIRS "${DIRS};${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
+    endif()
+
     # when installing, "fixup" automatically copies librairies inside the
     # bundle and links the binary against them
     install(CODE "
         include(BundleUtilities)
-        fixup_bundle(${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app \"\" \"\")
-    ")
+        fixup_bundle(${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app \"\" \"${DIRS}\")
+    " BUNDLE DESTINATION ${CMAKE_BINARY_DIR})
 endif()
 
 include_directories(${SDL2_INCLUDE_DIR})
@@ -526,7 +534,9 @@ if (VITA_BUILD)
     )
 else()
     target_link_libraries (${SHORT_NAME} ${SDL2_LIBRARY} ${SDL2_MIXER_LIBRARY})
-    install(TARGETS ${SHORT_NAME} RUNTIME DESTINATION bin)
+    if(NOT APPLE)
+        install(TARGETS ${SHORT_NAME} RUNTIME DESTINATION bin)
+    endif()
 
     # Unit tests
     enable_testing()

--- a/res/Info.plist.in
+++ b/res/Info.plist.in
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleGetInfoString</key>
+    <string>${MACOSX_BUNDLE_INFO_STRING}</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleLongVersionString</key>
+    <string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+    <key>CFBundleName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>CSResourcesFileMapped</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -339,13 +339,13 @@ static int pre_init(const char *custom_data_dir)
         return game_pre_init();
     }
 
-    if (SDL_VERSION_ATLEAST(2, 0, 1)) {
+    #if SDL_VERSION_ATLEAST(2, 0, 1)
         const char *base_path = SDL_GetBasePath();
         if (base_path) {
             chdir(base_path);
             SDL_free((void*) base_path);
         }
-    }
+    #endif
 
     SDL_Log("Loading game from working directory");
     if (game_pre_init()) {

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -338,6 +338,13 @@ static int pre_init(const char *custom_data_dir)
         }
         return game_pre_init();
     }
+
+    const char *base_path = SDL_GetBasePath();
+    if (base_path) {
+        chdir(base_path);
+        SDL_free((void*) base_path);
+    }
+
     SDL_Log("Loading game from working directory");
     if (game_pre_init()) {
         return 1;
@@ -349,6 +356,7 @@ static int pre_init(const char *custom_data_dir)
     SDL_Log("Julius requires the original files from Caesar 3 to run.");
     SDL_Log("Move the Julius executable to the directory containing an existing Caesar 3 installation, or run:");
     SDL_Log("julius path-to-c3-directory");
+
     return 0;
 }
 
@@ -368,7 +376,7 @@ static void setup(const char *custom_data_dir)
 	    SDL_Log("Exiting: vita2d init failed");
 	    exit(-1);
     }
-    
+
     // Black
     vita2d_set_clear_color(RGBA8(0, 0, 0, 255));
     sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
@@ -402,11 +410,19 @@ static void teardown(void)
 
 int main(int argc, char **argv)
 {
-    #ifdef __vita__
     const char *custom_data_dir = NULL;
-    #else
-    const char *custom_data_dir = (argc > 1 && argv[1]) ? argv[1] : NULL;
-    #endif
+    for (int i = 1; i < argc; i++) {
+        // we ignore "-psn" arguments, this is needed to launch the app
+        // from the Finder on macOS.
+        // https://hg.libsdl.org/SDL/file/c005c49beaa9/test/testdropfile.c#l47
+        if (SDL_strncmp(argv[i], "-psn", 4) == 0) {
+            continue;
+        }
+
+        custom_data_dir = argv[i];
+        break;
+    }
+
     setup(custom_data_dir);
 
     main_loop();

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -339,10 +339,12 @@ static int pre_init(const char *custom_data_dir)
         return game_pre_init();
     }
 
-    const char *base_path = SDL_GetBasePath();
-    if (base_path) {
-        chdir(base_path);
-        SDL_free((void*) base_path);
+    if (SDL_VERSION_ATLEAST(2, 0, 1)) {
+        const char *base_path = SDL_GetBasePath();
+        if (base_path) {
+            chdir(base_path);
+            SDL_free((void*) base_path);
+        }
     }
 
     SDL_Log("Loading game from working directory");


### PR DESCRIPTION
Hello,

This PR adds the possibility of building a .app bundle on macOS. It uses the CMake [MACOSX_BUNDLE](https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_BUNDLE.html) feature. If you want to test it: `mkdir build && cd build && cmake .. && make`.

Somes notes:

- most of the work is in the CMakeLists.txt, where I set some variables that will populate the bundle's Info.plist (like the bundle name/version/identifier/icon path)
- I added a bash script that auto-creates the macOS icon file (icns format) from the file "julius_256.png". This script is automatically called by CMake on build, and the ICNS file is copied into the bundle.
- while calling "make install", CMake will automatically copy the needed libraries into the "Frameworks" folder in the bundle, and link the binary against them. This makes the bundle distributable (see https://cmake.org/cmake/help/latest/module/BundleUtilities.html)
- the custom `Info.plist.in` is the default `MacOSXBundleInfo.plist.in` file from CMake 3.13.4, with one additional key "NSHighResolutionCapable" that fixes the DPI problem on Retina screens
- I arbitrarily set the minimum OSX deployment version to 10.10, but I suppose we can deploy for older systems (I had a working binary while setting this value at 10.6). I'm not sure which value is best.
- I have modified the argument handling in the function `main()` because the Finder automatically passes an argument "-psn_0_XXXXXX" as first argument when double-clicking on the bundle (see https://hg.libsdl.org/SDL/file/c005c49beaa9/test/testdropfile.c#l47).
- in the `pre_init()` function, I also added a `chdir()` to the [SDL_GetBasePath](https://wiki.libsdl.org/SDL_GetBasePath): this function returns the directory where the application is run from. On macOS/iOS, this function returns the path of the bundle's "Resources" directory (if the binary is inside a bundle). Which means that the user can just drag and drop Caesar III data inside the Resources folder (alongside the "julius.icns" file), and the bundle will work in an autonomous way. Note that it is still possible to pass a custom path: `./julius.app/Contents/MacOS/julius custom/path/to/caesarIII`.

This PR is related to #100 . Feel free to ask if you have any questions or code modification ideas.
