### PR TITLE
Reduce codecov build failures.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch: off


### PR DESCRIPTION
Currently a build fails if either the tested coverage of the PR's whole build and of the patch is below the master's coverage percentage.

That seems too strict, as some patches may be added to areas that weren't covered so they will always stick to 0% coverage, reduce the whole buld coverage and therefore fail the build.

This changes that behavior so the patches aren't checked and codecov only fails if the whole build's coverage falls by more than 0.5%.