### PR TITLE
Improve the visual feedback when clearing land.

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -508,9 +508,15 @@ void building_construction_start(int x, int y, int grid_offset)
 void building_construction_update(int x, int y, int grid_offset)
 {
     building_type type = data.type;
-    data.end.x = x;
-    data.end.y = y;
-    data.end.grid_offset = grid_offset;
+    if (grid_offset) {
+        data.end.x = x;
+        data.end.y = y;
+        data.end.grid_offset = grid_offset;
+    } else {
+        x = data.end.x;
+        y = data.end.y;
+        grid_offset = data.end.grid_offset;
+    }
     if (!type || city_finance_out_of_money()) {
         data.cost = 0;
         return;

--- a/src/building/construction_clear.c
+++ b/src/building/construction_clear.c
@@ -31,7 +31,7 @@ static building *get_deletable_building(int grid_offset)
     if (!building_id) {
         return 0;
     }
-    building *b = building_get(building_id);
+    building *b = building_main(building_get(building_id));
     if (b->type == BUILDING_BURNING_RUIN || b->type == BUILDING_NATIVE_CROPS ||
         b->type == BUILDING_NATIVE_HUT || b->type == BUILDING_NATIVE_MEETING) {
         return 0;
@@ -107,7 +107,6 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
                     }
                     space = building_get(space->prev_part_building_id);
                     game_undo_add_building(space);
-                    space->is_deleted = 1;
                     space->state = BUILDING_STATE_DELETED_BY_PLAYER;
                 }
                 space = b;
@@ -117,7 +116,6 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
                         break;
                     }
                     game_undo_add_building(space);
-                    space->is_deleted = 1;
                     space->state = BUILDING_STATE_DELETED_BY_PLAYER;
                 }
             } else if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT)) {

--- a/src/building/construction_clear.c
+++ b/src/building/construction_clear.c
@@ -36,7 +36,7 @@ static building *get_deletable_building(int grid_offset)
         b->type == BUILDING_NATIVE_HUT || b->type == BUILDING_NATIVE_MEETING) {
         return 0;
     }
-    if (b->state == BUILDING_STATE_DELETED_BY_PLAYER) {
+    if (b->state == BUILDING_STATE_DELETED_BY_PLAYER || b->is_deleted) {
         return 0;
     }
     return b;
@@ -59,12 +59,17 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
                     continue;
                 }
                 map_building_tiles_mark_deleting(grid_offset);
-                if (map_terrain_is(grid_offset, TERRAIN_ROCK | TERRAIN_ELEVATION) || // keep the "access ramp deletion costs money" bug from C3
-                   (map_terrain_is(grid_offset, TERRAIN_WATER) /**&& !map_is_bridge(grid_offset) **/)) { // keep the "bridge is free" bug from C3
+                if (map_terrain_is(grid_offset, TERRAIN_BUILDING)) {
+                    if (get_deletable_building(grid_offset)) {
+                        items_placed++;
+                    }
                     continue;
                 }
-                if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT) || map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR) ||
-                    (map_terrain_is(grid_offset, TERRAIN_BUILDING) && get_deletable_building(grid_offset))) {
+                if (map_terrain_is(grid_offset, TERRAIN_ROCK | TERRAIN_ELEVATION) || // keep the "access ramp deletion costs money" bug from C3
+                   (map_terrain_is(grid_offset, TERRAIN_WATER))) { // keep the "bridge is free" bug from C3
+                    continue;
+                }
+                if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT) || map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR)) {
                     items_placed++;
                 }
                 continue;

--- a/src/building/construction_clear.c
+++ b/src/building/construction_clear.c
@@ -107,6 +107,7 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
                     }
                     space = building_get(space->prev_part_building_id);
                     game_undo_add_building(space);
+                    space->is_deleted = 1;
                     space->state = BUILDING_STATE_DELETED_BY_PLAYER;
                 }
                 space = b;
@@ -116,6 +117,7 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
                         break;
                     }
                     game_undo_add_building(space);
+                    space->is_deleted = 1;
                     space->state = BUILDING_STATE_DELETED_BY_PLAYER;
                 }
             } else if (map_terrain_is(grid_offset, TERRAIN_AQUEDUCT)) {

--- a/src/building/construction_clear.c
+++ b/src/building/construction_clear.c
@@ -55,12 +55,13 @@ static int clear_land_confirmed(int measure_only, int x_start, int y_start, int 
         for (int x = x_min; x <= x_max; x++) {
             int grid_offset = map_grid_offset(x,y);
             if (measure_only) {
-                if (map_property_is_deleted(grid_offset)) {
+                building* b = get_deletable_building(grid_offset);
+                if (map_property_is_deleted(grid_offset) || (b && map_property_is_deleted(b->grid_offset))) {
                     continue;
                 }
                 map_building_tiles_mark_deleting(grid_offset);
                 if (map_terrain_is(grid_offset, TERRAIN_BUILDING)) {
-                    if (get_deletable_building(grid_offset)) {
+                    if (b) {
                         items_placed++;
                     }
                     continue;

--- a/src/map/bridge.c
+++ b/src/map/bridge.c
@@ -308,10 +308,8 @@ int map_bridge_count_figures(int grid_offset)
     if (map_has_figure_at(grid_offset)) {
         figures = 1;
     }
-    map_property_clear_deleted(grid_offset);
     while (map_is_bridge(grid_offset + offset_up)) {
         grid_offset += offset_up;
-        map_property_clear_deleted(grid_offset);
         if (map_has_figure_at(grid_offset)) {
             figures++;
         }

--- a/src/map/building_tiles.c
+++ b/src/map/building_tiles.c
@@ -302,25 +302,18 @@ void map_building_tiles_mark_deleting(int grid_offset)
         return;
     }
     int building_id = map_building_at(grid_offset);
-    if (building_id) {
-        building *b = building_get(building_id);
-        building *space = b;
-        for (int i = 0; i < 9; i++) {
-            if (space->prev_part_building_id <= 0) {
-                break;
-            }
-            space = building_get(space->prev_part_building_id);
-            mark_area_as_deleting(space->x, space->y, space->size);
+    if (!building_id) {
+        return;
+    }
+    building* b = building_main(building_get(building_id));
+    mark_area_as_deleting(b->x, b->y, building_is_farm(b->type) ? 3 : b->size);
+    building * part = b;
+    for (int i = 0; i < 9; i++) {
+        part = building_next(part);
+        if (part->id <= 0) {
+            break;
         }
-        space = b;
-        for (int i = 0; i < 9; i++) {
-            space = building_next(space);
-            if (space->id <= 0) {
-                break;
-            }
-            mark_area_as_deleting(space->x, space->y, space->size);
-        }
-        mark_area_as_deleting(b->x, b->y, (building_is_farm(b->type)) ? 3 : b->size);
+        mark_area_as_deleting(part->x, part->y, part->size);
     }
 }
 

--- a/src/map/building_tiles.c
+++ b/src/map/building_tiles.c
@@ -285,36 +285,15 @@ int map_building_tiles_mark_construction(int x, int y, int size, int terrain, in
     return 1;
 }
 
-static void mark_area_as_deleting(int x, int y, int size)
-{
-    for (int dy = 0; dy < size; ++dy) {
-        for (int dx = 0; dx < size; ++dx) {
-            map_property_mark_deleted(map_grid_offset(x + dx, y + dy));
-        }
-    }
-}
-
 void map_building_tiles_mark_deleting(int grid_offset)
 {
-    map_bridge_remove(grid_offset, 1);
-    if (!map_terrain_is(grid_offset, TERRAIN_BUILDING)) {
-        map_property_mark_deleted(grid_offset);
-        return;
-    }
     int building_id = map_building_at(grid_offset);
     if (!building_id) {
-        return;
+        map_bridge_remove(grid_offset, 1);
+    } else {
+        grid_offset = building_main(building_get(building_id))->grid_offset;
     }
-    building* b = building_main(building_get(building_id));
-    mark_area_as_deleting(b->x, b->y, building_is_farm(b->type) ? 3 : b->size);
-    building * part = b;
-    for (int i = 0; i < 9; i++) {
-        part = building_next(part);
-        if (part->id <= 0) {
-            break;
-        }
-        mark_area_as_deleting(part->x, part->y, part->size);
-    }
+    map_property_mark_deleted(grid_offset);
 }
 
 int map_building_tiles_are_clear(int x, int y, int size, int terrain)

--- a/src/map/building_tiles.h
+++ b/src/map/building_tiles.h
@@ -11,6 +11,8 @@ void map_building_tiles_remove(int building_id, int x, int y);
 
 void map_building_tiles_set_rubble(int building_id, int x, int y, int size);
 
+void map_building_tiles_mark_deleting(int grid_offset);
+
 int map_building_tiles_mark_construction(int x, int y, int size, int terrain, int absolute_xy);
 
 int map_building_tiles_are_clear(int x, int y, int size, int terrain);

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -137,7 +137,7 @@ static void build_start(const map_tile *tile)
 
 static void build_move(const map_tile *tile)
 {
-    if (!building_construction_in_progress() || !tile->grid_offset) {
+    if (!building_construction_in_progress()) {
         return;
     }
     building_construction_update(tile->x, tile->y, tile->grid_offset);

--- a/src/widget/city_building_ghost.h
+++ b/src/widget/city_building_ghost.h
@@ -3,7 +3,7 @@
 
 #include "map/point.h"
 
-void city_building_ghost_mark_deleting(const map_tile *tile);
+int city_building_ghost_mark_deleting(const map_tile *tile);
 void city_building_ghost_draw(const map_tile *tile);
 
 #endif // WIDGET_CITY_BUILDING_GHOST_H

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -64,7 +64,7 @@ static void draw_footprint(int x, int y, int grid_offset)
         color_t color_mask = 0;
         if (building_id) {
             building *b = building_get(building_id);
-            if (b->is_deleted) {
+            if (b->is_deleted || map_property_is_deleted(grid_offset)) {
                 color_mask = COLOR_MASK_RED;
             }
             int view_x, view_y, view_width, view_height;
@@ -424,7 +424,7 @@ static void draw_hippodrome_ornaments(int x, int y, int grid_offset)
 
 static void process_deleted(int x, int y, int grid_offset)
 {
-    if (map_property_is_deleted(grid_offset)) {
+    if (map_property_is_deleted(grid_offset) && !map_building_at(grid_offset)) {
         image_draw_blend(image_group(GROUP_TERRAIN_FLAT_TILE), x, y, COLOR_MASK_RED);
     }
     map_property_clear_deleted(grid_offset);

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -232,7 +232,7 @@ static void draw_top(int x, int y, int grid_offset)
     building *b = building_get(map_building_at(grid_offset));
     int image_id = map_image_at(grid_offset);
     color_t color_mask = 0;
-    if ((b->id && b->is_deleted) || (!map_terrain_is(grid_offset, TERRAIN_ROCK | TERRAIN_ACCESS_RAMP) && map_property_is_deleted(grid_offset))) {
+    if ((b->id && b->is_deleted) || (!map_terrain_is(grid_offset, TERRAIN_ROCK | TERRAIN_ACCESS_RAMP | TERRAIN_GARDEN) && map_property_is_deleted(grid_offset))) {
         color_mask = COLOR_MASK_RED;
     }
     image_draw_isometric_top_from_draw_tile(image_id, x, y, color_mask);

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -373,7 +373,7 @@ static void draw_animation(int x, int y, int grid_offset)
                 case FIGURE_FORT_JAVELIN: offset = 2; break;
             }
             if (offset) {
-                image_draw_masked(image_group(GROUP_BUILDING_FORT) + offset, x + 81, y + 5, map_property_is_deleted(grid_offset) ? COLOR_MASK_RED : 0);
+                image_draw_masked(image_group(GROUP_BUILDING_FORT) + offset, x + 81, y + 5, (map_property_is_deleted(grid_offset) || fort->is_deleted) ? COLOR_MASK_RED : 0);
             }
         }
     } else if (building_get(map_building_at(grid_offset))->type == BUILDING_GATEHOUSE) {
@@ -385,7 +385,7 @@ static void draw_animation(int x, int y, int grid_offset)
             (orientation == DIR_6_LEFT && xy == EDGE_X1Y0)) {
             building *gate = building_get(map_building_at(grid_offset));
             int image_id = image_group(GROUP_BULIDING_GATEHOUSE);
-            int color_mask = (map_property_is_deleted(grid_offset)) ? COLOR_MASK_RED : 0;
+            int color_mask = (map_property_is_deleted(grid_offset) || gate->is_deleted) ? COLOR_MASK_RED : 0;
             if (gate->subtype.orientation == 1) {
                 if (orientation == DIR_0_TOP || orientation == DIR_4_BOTTOM) {
                     image_draw_masked(image_id, x - 22, y - 80, color_mask);
@@ -422,7 +422,7 @@ static void draw_hippodrome_ornaments(int x, int y, int grid_offset)
     if (img->num_animation_sprites
         && map_property_is_draw_tile(grid_offset)
         && building_get(map_building_at(grid_offset))->type == BUILDING_HIPPODROME) {
-        image_draw_masked(image_id + 1, x + img->sprite_offset_x, y + img->sprite_offset_y - img->height + 90, map_property_is_deleted(grid_offset) ? COLOR_MASK_RED : 0);
+        image_draw_masked(image_id + 1, x + img->sprite_offset_x, y + img->sprite_offset_y - img->height + 90, (map_property_is_deleted(grid_offset) || building_get(map_building_at(grid_offset))->is_deleted) ? COLOR_MASK_RED : 0);
     }
 }
 

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -50,7 +50,7 @@ static void init_draw_context(int selected_figure_id, pixel_coordinate *figure_c
     draw_context.selected_figure_coord = figure_coord;
 }
 
-static int draw_building_as_deleted(building* b)
+static int draw_building_as_deleted(building *b)
 {
     b = building_main(b);
     return (b->id && (b->is_deleted || map_property_is_deleted(b->grid_offset)));
@@ -71,7 +71,6 @@ static void draw_footprint(int x, int y, int grid_offset)
         // Valid grid_offset and leftmost tile -> draw
         int building_id = map_building_at(grid_offset);
         color_t color_mask = 0;
-
         if (building_id) {
             building *b = building_get(building_id);
             if (draw_building_as_deleted(b)) {
@@ -461,10 +460,8 @@ static void clear_deleted(int x, int y, int grid_offset)
 void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile)
 {
     init_draw_context(selected_figure_id, figure_coord);
-
     int should_mark_deleting = city_building_ghost_mark_deleting(tile);
     city_view_foreach_map_tile(draw_footprint);
-
     if (!should_mark_deleting) {
         city_view_foreach_valid_map_tile(
             draw_top,


### PR DESCRIPTION
If the "clear land" tool is selected, the tile the mouse is hovered on
will be highlighted in red. If that tile is a building, the whole
building will be highlighted.

If the "clear land" tool is dragged, the area to be cleared will be
highlighted in red. If the area includes buildings, the entire building
will be highlighted.

Fixes #103.