### PR TITLE
added a simple message box when data files are not found at launch

### DIFF
--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -365,6 +365,12 @@ static int pre_init(const char *custom_data_dir)
     SDL_Log("Move the Julius executable to the directory containing an existing Caesar 3 installation, or run:");
     SDL_Log("julius path-to-c3-directory");
 
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+        "Julius requires the original files from Caesar 3 to run",
+        "Move the Julius executable to the directory containing an existing "
+        "Caesar 3 installation, or run: julius path-to-c3-directory",
+        NULL);
+
     return 0;
 }
 


### PR DESCRIPTION
On some systems (such as macOS/Windows), users don't have access to the console while running Julius. This means the user won't see logs such as `INFO: Julius requires the original files from Caesar 3 to run [...]`. This PR adds a simple message box using [SDL_ShowSimpleMessageBox](https://wiki.libsdl.org/SDL_ShowSimpleMessageBox) when the C3 files are not found at launch.