### PR TITLE
Fixes the random game crashes when closing a message with video playing.

### DIFF
--- a/src/graphics/video.c
+++ b/src/graphics/video.c
@@ -189,13 +189,13 @@ int video_is_finished(void)
 void video_stop(void)
 {
     if (data.is_playing) {
+        if (!data.is_ended) {
+            end_video();
+        }
         if (data.video.s) {
             close_all();
         }
         data.is_playing = 0;
-        if (!data.is_ended) {
-            end_video();
-        }
     }
 }
 

--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -265,11 +265,11 @@ void sound_device_use_custom_music_player(int bitdepth, int num_channels, int ra
 
 void sound_device_use_default_music_player(void)
 {
+    Mix_HookMusic(0, 0);
     if (custom_music.data) {
         free(custom_music.data);
         custom_music.data = 0;
         custom_music.len = 0;
         custom_music.cur = 0;
     }
-    Mix_HookMusic(0, 0);
 }


### PR DESCRIPTION
The crash was cause by a race condition between `smk_close` and `Mix_HookMusic`.

This was tested and fixed by calling `sleep(1)` during memory freeing in `smk_close`. Using `sleep` to simulate a thread interruption, the old code always crashed when the message was closed while the video was playing. The new code doesn't crash.

Hopefully this improves things for Vita/Switch as well.