### PR TITLE
Make the minimap image update immediately on map rotate.

### DIFF
--- a/src/game/orientation.c
+++ b/src/game/orientation.c
@@ -4,11 +4,13 @@
 #include "city/warning.h"
 #include "core/direction.h"
 #include "map/orientation.h"
+#include "widget/sidebar.h"
 
 void game_orientation_rotate_left(void)
 {
     city_view_rotate_left();
     map_orientation_change(0);
+    widget_sidebar_invalidate_minimap();
     city_warning_show(WARNING_ORIENTATION);
 }
 
@@ -16,6 +18,7 @@ void game_orientation_rotate_right(void)
 {
     city_view_rotate_right();
     map_orientation_change(1);
+    widget_sidebar_invalidate_minimap();
     city_warning_show(WARNING_ORIENTATION);
 }
 
@@ -37,5 +40,6 @@ void game_orientation_rotate_north(void)
         default: // already north
             return;
     }
+    widget_sidebar_invalidate_minimap();
     city_warning_show(WARNING_ORIENTATION);
 }


### PR DESCRIPTION
I forgot to invalidate the minimap buffer on map rotate on PR #101, so it didn't immediately update. This was especially noticeable if the game was paused.

The bug is now fixed.