### PR TITLE
Support for Azerty keyboards in game

### DIFF
--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -163,10 +163,10 @@ void hotkey_character(int c)
                 break;
 
             // Azerty keyboards need alt gr for these keys
-            case '[':
+            case '[': case '5':
                 change_game_speed(1);
                 break;
-            case ']':
+            case ']': case '-':
                 change_game_speed(0);
                 break;
         }

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -150,94 +150,85 @@ void hotkey_character(int c)
 {
     if (data.alt_down) {
         switch (c) {
-            case SDLK_x: //'X'
+            case 'X': case 'x':
                 hotkey_esc();
                 break;
-            case SDLK_k: //'K'
+            case 'K': case 'k':
                 cheat_init_or_invasion();
-            case SDLK_c: //'C'
+            case 'C': case 'c':
                 cheat_money();
                 break;
-            case SDLK_v: //'V'
+            case 'V': case 'v':
                 cheat_victory();
-                break;
-
-            // Azerty keyboards need alt gr for these keys
-            case SDL_SCANCODE_5: //'['
-                change_game_speed(1);
-                break;
-            case SDL_SCANCODE_MINUS: //']'
-                change_game_speed(0);
                 break;
         }
         return;
     }
-
     switch (c) {
-        case SDLK_LEFTBRACKET: //'['
+        case '[':
             change_game_speed(1);
             break;
-        case SDLK_RIGHTBRACKET: //']'
+        case ']':
             change_game_speed(0);
             break;
-        case SDL_SCANCODE_SPACE: //' '
+        case ' ':
             toggle_overlay();
             break;
-        case SDLK_p: //'P'
+        case 'P': case 'p':
             toggle_pause();
             break;
-        case SDLK_f: //'F'
+        case 'F': case 'f':
             show_overlay(OVERLAY_FIRE);
             break;
-        case SDLK_d: //'D'
+        case 'D': case 'd':
             show_overlay(OVERLAY_DAMAGE);
             break;
-        case SDLK_c: //'C'
+        case 'C': case 'c':
             show_overlay(OVERLAY_CRIME);
             break;
-        case SDLK_t: //'T'
+        case 'T': case 't':
             show_overlay(OVERLAY_PROBLEMS);
             break;
-        case SDLK_w: //'W'
+        case 'W': case 'w':
             show_overlay(OVERLAY_WATER);
             break;
-        case SDLK_l: //'L'
+        case 'L': case 'l':
             cycle_legion();
             break;
-        case SDL_SCANCODE_1: //'1':
+        case '1':
             show_advisor(ADVISOR_LABOR);
             break;
-        case SDL_SCANCODE_2: //'2':
+        case '2':
             show_advisor(ADVISOR_MILITARY);
             break;
-        case SDL_SCANCODE_3: //'3':
+        case '3':
             show_advisor(ADVISOR_IMPERIAL);
             break;
-        case SDL_SCANCODE_4: //'4':
+        case '4':
             show_advisor(ADVISOR_RATINGS);
             break;
-        case SDL_SCANCODE_5: //'5':
+        case '5':
             show_advisor(ADVISOR_TRADE);
             break;
-        case SDL_SCANCODE_6: //'6':
+        case '6':
             show_advisor(ADVISOR_POPULATION);
             break;
-        case SDL_SCANCODE_7: //'7':
+        case '7':
             show_advisor(ADVISOR_HEALTH);
             break;
-        case SDL_SCANCODE_8: //'8':
+        case '8':
             show_advisor(ADVISOR_EDUCATION);
             break;
-        case SDL_SCANCODE_9: //'9':
+        case '9':
             show_advisor(ADVISOR_ENTERTAINMENT);
             break;
-        case SDL_SCANCODE_0: //'0':
+        case '0':
             show_advisor(ADVISOR_RELIGION);
             break;
-        case SDL_SCANCODE_MINUS: //'-':
+        case '-':
             show_advisor(ADVISOR_FINANCIAL);
             break;
-        case SDL_SCANCODE_EQUALS: // '='
+        case '=':
             show_advisor(ADVISOR_CHIEF);
             break;
     }

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -161,9 +161,18 @@ void hotkey_character(int c)
             case 'V': case 'v':
                 cheat_victory();
                 break;
+
+            // Azerty keyboards need alt gr for these keys
+            case '[':
+                change_game_speed(1);
+                break;
+            case ']':
+                change_game_speed(0);
+                break;
         }
         return;
     }
+
     switch (c) {
         case '[':
             change_game_speed(1);

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -150,85 +150,94 @@ void hotkey_character(int c)
 {
     if (data.alt_down) {
         switch (c) {
-            case 'X': case 'x':
+            case SDLK_x: //'X'
                 hotkey_esc();
                 break;
-            case 'K': case 'k':
+            case SDLK_k: //'K'
                 cheat_init_or_invasion();
-            case 'C': case 'c':
+            case SDLK_c: //'C'
                 cheat_money();
                 break;
-            case 'V': case 'v':
+            case SDLK_v: //'V'
                 cheat_victory();
+                break;
+
+            // Azerty keyboards need alt gr for these keys
+            case SDL_SCANCODE_5: //'['
+                change_game_speed(1);
+                break;
+            case SDL_SCANCODE_MINUS: //']'
+                change_game_speed(0);
                 break;
         }
         return;
     }
+
     switch (c) {
-        case '[':
+        case SDLK_LEFTBRACKET: //'['
             change_game_speed(1);
             break;
-        case ']':
+        case SDLK_RIGHTBRACKET: //']'
             change_game_speed(0);
             break;
-        case ' ':
+        case SDL_SCANCODE_SPACE: //' '
             toggle_overlay();
             break;
-        case 'P': case 'p':
+        case SDLK_p: //'P'
             toggle_pause();
             break;
-        case 'F': case 'f':
+        case SDLK_f: //'F'
             show_overlay(OVERLAY_FIRE);
             break;
-        case 'D': case 'd':
+        case SDLK_d: //'D'
             show_overlay(OVERLAY_DAMAGE);
             break;
-        case 'C': case 'c':
+        case SDLK_c: //'C'
             show_overlay(OVERLAY_CRIME);
             break;
-        case 'T': case 't':
+        case SDLK_t: //'T'
             show_overlay(OVERLAY_PROBLEMS);
             break;
-        case 'W': case 'w':
+        case SDLK_w: //'W'
             show_overlay(OVERLAY_WATER);
             break;
-        case 'L': case 'l':
+        case SDLK_l: //'L'
             cycle_legion();
             break;
-        case '1':
+        case SDL_SCANCODE_1: //'1':
             show_advisor(ADVISOR_LABOR);
             break;
-        case '2':
+        case SDL_SCANCODE_2: //'2':
             show_advisor(ADVISOR_MILITARY);
             break;
-        case '3':
+        case SDL_SCANCODE_3: //'3':
             show_advisor(ADVISOR_IMPERIAL);
             break;
-        case '4':
+        case SDL_SCANCODE_4: //'4':
             show_advisor(ADVISOR_RATINGS);
             break;
-        case '5':
+        case SDL_SCANCODE_5: //'5':
             show_advisor(ADVISOR_TRADE);
             break;
-        case '6':
+        case SDL_SCANCODE_6: //'6':
             show_advisor(ADVISOR_POPULATION);
             break;
-        case '7':
+        case SDL_SCANCODE_7: //'7':
             show_advisor(ADVISOR_HEALTH);
             break;
-        case '8':
+        case SDL_SCANCODE_8: //'8':
             show_advisor(ADVISOR_EDUCATION);
             break;
-        case '9':
+        case SDL_SCANCODE_9: //'9':
             show_advisor(ADVISOR_ENTERTAINMENT);
             break;
-        case '0':
+        case SDL_SCANCODE_0: //'0':
             show_advisor(ADVISOR_RELIGION);
             break;
-        case '-':
+        case SDL_SCANCODE_MINUS: //'-':
             show_advisor(ADVISOR_FINANCIAL);
             break;
-        case '=':
+        case SDL_SCANCODE_EQUALS: // '='
             show_advisor(ADVISOR_CHIEF);
             break;
     }

--- a/src/input/hotkey.h
+++ b/src/input/hotkey.h
@@ -1,6 +1,9 @@
 #ifndef INPUT_HOTKEY_H
 #define INPUT_HOTKEY_H
 
+#include "SDL.h"
+#include "SDL_scancode.h"
+
 void hotkey_character(int c);
 
 void hotkey_left(void);

--- a/src/input/hotkey.h
+++ b/src/input/hotkey.h
@@ -1,9 +1,6 @@
 #ifndef INPUT_HOTKEY_H
 #define INPUT_HOTKEY_H
 
-#include "SDL.h"
-#include "SDL_scancode.h"
-
 void hotkey_character(int c);
 
 void hotkey_left(void);

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -89,18 +89,9 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
         case SDLK_RSHIFT:
             hotkey_shift(1);
             break;
-        case SDLK_LEFTBRACKET:
-        case SDLK_RIGHTBRACKET:
-            hotkey_character(event->keysym.sym);
-            break;
         default:
             if ((event->keysym.sym & SDLK_SCANCODE_MASK) == 0) {
-                // Send key codes only for letters (layout dependent codes)
-                // Other keys like numbers seem to be non-layout dependent
-                if (event->keysym.sym >= 97 && event->keysym.sym <= 122)
-                    hotkey_character(event->keysym.sym);
-                else
-                    hotkey_character(event->keysym.scancode);
+                hotkey_character(event->keysym.sym);
             }
             break;
     }

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -89,10 +89,58 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
         case SDLK_RSHIFT:
             hotkey_shift(1);
             break;
+        case SDLK_LEFTBRACKET:
+        case SDLK_RIGHTBRACKET:
+            hotkey_character(event->keysym.sym);
+            break;
         default:
             if ((event->keysym.sym & SDLK_SCANCODE_MASK) == 0) {
-                hotkey_character(event->keysym.sym);
+                // Send keycodes only for letters (layout dependent codes)
+                if (event->keysym.sym >= 97 && event->keysym.sym <= 122)
+                    hotkey_character(event->keysym.sym);
             }
+            break;
+    }
+
+    // Send scancodes for non-layout dependent keys
+    switch (event->keysym.scancode) {
+        case SDL_SCANCODE_1:
+            hotkey_character('1');
+            break;
+        case SDL_SCANCODE_2:
+            hotkey_character('2');
+            break;
+        case SDL_SCANCODE_3:
+            hotkey_character('3');
+            break;
+        case SDL_SCANCODE_4:
+            hotkey_character('4');
+            break;
+        case SDL_SCANCODE_5:
+            hotkey_character('5');
+            break;
+        case SDL_SCANCODE_6:
+            hotkey_character('6');
+            break;
+        case SDL_SCANCODE_7:
+            hotkey_character('7');
+            break;
+        case SDL_SCANCODE_8:
+            hotkey_character('8');
+            break;
+        case SDL_SCANCODE_9:
+            hotkey_character('9');
+            break;
+        case SDL_SCANCODE_0:
+            hotkey_character('0');
+            break;
+        case SDL_SCANCODE_MINUS:
+            hotkey_character('-');
+            break;
+        case SDL_SCANCODE_EQUALS:
+            hotkey_character('=');
+            break;
+        default:
             break;
     }
 }

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -106,40 +106,18 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
     // Send scancodes for non-layout dependent keys
     switch (event->keysym.scancode) {
         case SDL_SCANCODE_1:
-            hotkey_character('1');
-            break;
         case SDL_SCANCODE_2:
-            hotkey_character('2');
-            break;
         case SDL_SCANCODE_3:
-            hotkey_character('3');
-            break;
         case SDL_SCANCODE_4:
-            hotkey_character('4');
-            break;
         case SDL_SCANCODE_5:
-            hotkey_character('5');
-            break;
         case SDL_SCANCODE_6:
-            hotkey_character('6');
-            break;
         case SDL_SCANCODE_7:
-            hotkey_character('7');
-            break;
         case SDL_SCANCODE_8:
-            hotkey_character('8');
-            break;
         case SDL_SCANCODE_9:
-            hotkey_character('9');
-            break;
         case SDL_SCANCODE_0:
-            hotkey_character('0');
-            break;
         case SDL_SCANCODE_MINUS:
-            hotkey_character('-');
-            break;
         case SDL_SCANCODE_EQUALS:
-            hotkey_character('=');
+            hotkey_character(*SDL_GetScancodeName(event->keysym.scancode));
             break;
         default:
             break;

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -91,6 +91,7 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
             break;
         case SDLK_LEFTBRACKET:
         case SDLK_RIGHTBRACKET:
+        case SDLK_SPACE:
             hotkey_character(event->keysym.sym);
             break;
         default:

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -89,9 +89,18 @@ void platform_handle_key_down(SDL_KeyboardEvent *event)
         case SDLK_RSHIFT:
             hotkey_shift(1);
             break;
+        case SDLK_LEFTBRACKET:
+        case SDLK_RIGHTBRACKET:
+            hotkey_character(event->keysym.sym);
+            break;
         default:
             if ((event->keysym.sym & SDLK_SCANCODE_MASK) == 0) {
-                hotkey_character(event->keysym.sym);
+                // Send key codes only for letters (layout dependent codes)
+                // Other keys like numbers seem to be non-layout dependent
+                if (event->keysym.sym >= 97 && event->keysym.sym <= 122)
+                    hotkey_character(event->keysym.sym);
+                else
+                    hotkey_character(event->keysym.scancode);
             }
             break;
     }


### PR DESCRIPTION
First of all I want to thank you for this huge job. I am in admiration for this huge project to revive a game of our childhood.

The game on Linux is much cheaper in CPU resources than using Wine, and the free license (not just open source: p) allows us to contribute to this work!

--

I'm using an Azerty keyboard and I'm having some issues with keyboard shortcuts in play.

Shortcuts involving the following keys do not work:
[,], 1,2,3,4,5,7,8,9,0

Key 6 opens the ADVISOR_FINANCIAL tab instead of ADVISOR_POPULATION.

This is normal since the numbers are entered with the shift key as a modifier.


In this pull request I assume that codes for letters are supposed to be layout dependent, so keycodes are still used.
However the keys involving the numbers are dependent on modifiers but they are still in the same place on a keyboard, so I propose to use their scancodes rather than their keycodes; they are independent of the layout used and refer to the physical location of a key on the keyboard.
This also allows a big improvement for Azerty keyboard users over the original game as they no longer need to press shift to open the city advisor boards.

I also take the opportunity to restore default shortcuts to adjust the game speed with 'Altgr' and '[' or ']'.

Also, `keysym.sym` only returns the ASCII code of the lowercase letter, so you it is not needed to test the capital letter as well, so I use the variables provided by the SDL directly.


I am largely inspired by these 2 pages:
https://wiki.libsdl.org/SDL_Keycode
https://wiki.libsdl.org/MigrationGuide

If the pull request does not match you, maybe it will give you some tips to solve these international keyboards problems.

Thanks again for this great job!