### PR TITLE
Vita: fix stuttery video playback by pre-loading videos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,9 @@ if (VITA_BUILD)
         ScePgf_stub
         SceAppMgr_stub
     )
-
+    # this setting enables larger heap memory sizes on Vita, up to ~330 MB
+    # useful for pre-loading videos into memory
+    set(VITA_MKSFOEX_FLAGS "${VITA_MKSFOEX_FLAGS} -d ATTRIBUTE2=12")
     vita_create_self(${SHORT_NAME}.self ${SHORT_NAME} UNSAFE UNCOMPRESSED)
     vita_create_vpk(${SHORT_NAME}.vpk ${VITA_TITLEID} ${SHORT_NAME}.self
         VERSION ${VITA_VERSION}

--- a/src/graphics/video.c
+++ b/src/graphics/video.c
@@ -75,7 +75,13 @@ static const unsigned char *next_audio_frame(int *out_len)
 static int load_smk_video(const char *filename)
 {
     FILE *fp = file_open(filename, "rb");
+#ifdef __vita__
+    // Vita file i/o is too slow to play videos smoothly from disk, so pre-load
+    // the pre-loading causes a short pause before video starts
+    data.video.s = smk_open_filepointer(fp, SMK_MODE_MEMORY);
+#else
     data.video.s = smk_open_filepointer(fp, SMK_MODE_DISK);
+#endif
     if (!data.video.s) {
         // smk_open_filepointer closes the stream on error: no need to close fp
         return 0;
@@ -108,7 +114,13 @@ static int load_smk_audio(const char *filename)
     }
 
     FILE *fp = file_open(filename, "rb");
+#ifdef __vita__
+    // Vita file i/o is too slow to play videos smoothly from disk, so pre-load
+    // the pre-loading causes a short pause before video starts
+    data.audio.s = smk_open_filepointer(fp, SMK_MODE_MEMORY);
+#else
     data.audio.s = smk_open_filepointer(fp, SMK_MODE_DISK);
+#endif
     if (!data.audio.s) {
         // smk_open_filepointer closes the stream on error: no need to close fp
         return 0;

--- a/src/platform/vita/vita.c
+++ b/src/platform/vita/vita.c
@@ -5,7 +5,8 @@
 #include <malloc.h>
 #include "SDL.h"
 
-int _newlib_heap_size_user = 192 * 1024 * 1024;
+// max heap size is approx. 330 MB with -d ATTRIBUTE2=12, otherwise max is 192
+int _newlib_heap_size_user = 300 * 1024 * 1024;
 
 int chdir(const char *path)
 {


### PR DESCRIPTION
This fixes the stuttery video playback on Vita by pre-loading videos into heap memory. The stuttery video were due to the extraordinarily slow file i/o on this platform.

The pre-loading causes a short pause before the video is played. That's why I only enabled pre-loading on the Vita platform.