### PR TITLE
Vita: ignore rear panel touch events

### DIFF
--- a/src/platform/vita/vita_input.c
+++ b/src/platform/vita/vita_input.c
@@ -80,6 +80,15 @@ int vita_poll_event(SDL_Event *event)
             vita_handle_touch(event);
         }
         switch (event->type) {
+            case SDL_FINGERDOWN:
+            case SDL_FINGERUP:
+            case SDL_FINGERMOTION: // intentional fallthrough
+                // ignore rear panel touch events
+                if (event->tfinger.touchId != 0) {
+                    event->type = SDL_USEREVENT;
+                    event->user.code = -1; // ensure that this event is ignored
+                }
+                break;
             case SDL_MOUSEMOTION:
                 // update joystick / touch mouse coords
                 last_mouse_x = event->motion.x;


### PR DESCRIPTION
This PR completely disables the Vita rear touch panel. This fixes unintended touch inputs when holding the Vita in such a way where fingers rest on the rear panel.