### PR TITLE
TinyDialogs & C3 Folder selection fix for MinGW-w64 compiler

### DIFF
--- a/ext/tinyfiledialogs/tinyfiledialogs.c
+++ b/ext/tinyfiledialogs/tinyfiledialogs.c
@@ -104,7 +104,7 @@ misrepresented as being the original software.
 #include "tinyfiledialogs.h"
 
 #ifdef USE_TINYFILEDIALOGS
-/* #define TINYFD_NOLIB */ 
+/* #define TINYFD_NOLIB */
 
 #ifdef _WIN32
  #ifdef __BORLANDC__
@@ -347,7 +347,7 @@ static void replaceSubStr( char const * const aSource ,
         char const * p ;
         char const * lNewSubStr = "" ;
         size_t lOldSubLen = strlen( aOldSubStr ) ;
-        
+
         if ( ! aSource )
         {
                 * aoDestination = '\0' ;
@@ -484,7 +484,7 @@ static int dirExists(char const * const aDirPath)
         struct stat lInfo;
 
         if (!aDirPath || !strlen(aDirPath))
-                return 0;       
+                return 0;
         if (stat(aDirPath, &lInfo) != 0)
                 return 0;
         else if ( tinyfd_winUtf8 )
@@ -625,7 +625,7 @@ static void RGB2HexW(
                 {
                         /* wprintf(L"aoResultHexRGB %s\n", aoResultHexRGB); */
                         swprintf(aoResultHexRGB,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                                 8,
 #endif
                         L"#%02hhx%02hhx%02hhx", aRGB[0], aRGB[1], aRGB[2]);
@@ -672,7 +672,7 @@ static int sizeMbcs(wchar_t const * const aMbcsString)
 static wchar_t * utf8to16(char const * const aUtf8string)
 {
         wchar_t * lUtf16string ;
-        int lSize = sizeUtf16(aUtf8string);     
+        int lSize = sizeUtf16(aUtf8string);
         lUtf16string = (wchar_t *) malloc( lSize * sizeof(wchar_t) );
         lSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
                                         aUtf8string, -1, lUtf16string, lSize);
@@ -858,7 +858,7 @@ static char const * ensureFilesExist(char * const aDestination,
 #ifndef TINYFD_NOLIB
 
 static int __stdcall EnumThreadWndProc(HWND hwnd, LPARAM lParam)
-{ 
+{
         wchar_t lTitleName[MAX_PATH];
         GetWindowTextW(hwnd, lTitleName, MAX_PATH);
         /* wprintf(L"lTitleName %ls \n", lTitleName);  */
@@ -1072,7 +1072,7 @@ Show-BalloonTip");
 static int notifyWinGui(
         char const * const aTitle, /* NULL or "" */
         char const * const aMessage, /* NULL or "" may NOT contain \n nor \t */
-        char const * const aIconType) 
+        char const * const aIconType)
 {
         wchar_t * lTitle;
         wchar_t * lMessage;
@@ -1124,7 +1124,7 @@ wchar_t const * tinyfd_inputBoxW(
         if (aDefaultInput)
         {
 			swprintf(lDialogString,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                         lDialogStringLen,
 #endif
                 L"%ls\\AppData\\Local\\Temp\\tinyfd.vbs", _wgetenv(L"USERPROFILE"));
@@ -1132,7 +1132,7 @@ wchar_t const * tinyfd_inputBoxW(
         else
         {
                 swprintf(lDialogString,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                         lDialogStringLen,
 #endif
                         L"%ls\\AppData\\Local\\Temp\\tinyfd.hta", _wgetenv(L"USERPROFILE"));
@@ -1263,7 +1263,7 @@ name = 'txt_input' value = '' style = 'float:left;width:100%' ><BR>\n\
         if (aDefaultInput)
         {
                 swprintf(lDialogString,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                         lDialogStringLen,
 #endif
                         L"%ls\\AppData\\Local\\Temp\\tinyfd.txt",_wgetenv(L"USERPROFILE"));
@@ -1292,7 +1292,7 @@ name = 'txt_input' value = '' style = 'float:left;width:100%' ><BR>\n\
         hiddenConsoleW(lDialogString, aTitle, 1);
 
         swprintf(lDialogString,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                 lDialogStringLen,
 #endif
 				L"%ls\\AppData\\Local\\Temp\\tinyfd.txt", _wgetenv(L"USERPROFILE"));
@@ -1319,7 +1319,7 @@ name = 'txt_input' value = '' style = 'float:left;width:100%' ><BR>\n\
 		if (aDefaultInput)
 		{
 			swprintf(lDialogString,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                         lDialogStringLen,
 #endif
                         L"%ls\\AppData\\Local\\Temp\\tinyfd.vbs",
@@ -1328,7 +1328,7 @@ name = 'txt_input' value = '' style = 'float:left;width:100%' ><BR>\n\
         else
         {
                 swprintf(lDialogString,
-#if !defined(__BORLANDC__) && !defined(__TINYC__) && !defined(__MINGW32__) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
+#if !defined(__BORLANDC__) && !defined(__TINYC__) && ( !defined(__MINGW32__) || defined(__MINGW64__) ) && ( !defined(__GNUC__) || (__GNUC__) >= 5 )
                         lDialogStringLen,
 #endif
                         L"%ls\\AppData\\Local\\Temp\\tinyfd.hta",
@@ -1342,7 +1342,7 @@ name = 'txt_input' value = '' style = 'float:left;width:100%' ><BR>\n\
 #else
 		lResult = !wcsncmp(lBuff, L"1", 1);
 #endif
-        
+
         /* printf( "lResult: %d \n" , lResult ) ; */
         if (!lResult)
         {
@@ -1565,7 +1565,7 @@ wchar_t const * tinyfd_openFileDialogW(
         int const aAllowMultipleSelects) /* 0 or 1 */
 {
         static wchar_t lBuff[MAX_MULTIPLE_FILES*MAX_PATH_OR_CMD];
-                
+
         size_t lLengths[MAX_MULTIPLE_FILES];
         wchar_t lDirname[MAX_PATH_OR_CMD];
         wchar_t lFilterPatterns[MAX_PATH_OR_CMD] = L"";
@@ -1767,7 +1767,7 @@ wchar_t const * tinyfd_selectFolderDialogW(
         wchar_t const * const aDefaultPath) /* NULL or "" */
 {
         static wchar_t lBuff[MAX_PATH_OR_CMD];
-                
+
         BROWSEINFOW bInfo;
         LPITEMIDLIST lpItem;
         HRESULT lHResult;
@@ -1944,7 +1944,7 @@ static int messageBoxWinGuiA(
 {
         int lBoxReturnValue;
     UINT aCode ;
-        
+
         if ( aIconType && ! strcmp( "warning" , aIconType ) )
         {
                 aCode = MB_ICONWARNING ;
@@ -2042,7 +2042,7 @@ static char const * saveFileDialogWinGuiA(
 
         getPathWithoutFinalSlash(lDirname, aDefaultPathAndFile);
         getLastName(aoBuff, aDefaultPathAndFile);
-    
+
         if (aNumOfFilterPatterns > 0)
         {
                 if ( aSingleFilterDescription && strlen(aSingleFilterDescription) )
@@ -2070,7 +2070,7 @@ static char const * saveFileDialogWinGuiA(
                         p ++ ;
                 }
         }
-    
+
         ofn.lStructSize     = sizeof(OPENFILENAME) ;
         ofn.hwndOwner           = GetForegroundWindow();
         ofn.hInstance       = 0 ;
@@ -2097,12 +2097,12 @@ static char const * saveFileDialogWinGuiA(
         {
                 lRetval = NULL ;
         }
-        else 
-        { 
+        else
+        {
                 lRetval = aoBuff ;
         }
 
-        if (lHResult==S_OK || lHResult==S_FALSE) 
+        if (lHResult==S_OK || lHResult==S_FALSE)
         {
                 CoUninitialize();
         }
@@ -2194,7 +2194,7 @@ static char const * openFileDialogWinGuiA(
         {
                 lRetval = NULL ;
         }
-        else 
+        else
         {
                 lBuffLen = strlen(aoBuff) ;
                 lPointers[0] = aoBuff + lBuffLen + 1 ;
@@ -2202,7 +2202,7 @@ static char const * openFileDialogWinGuiA(
                 {
                         lRetval = aoBuff ;
                 }
-                else 
+                else
                 {
                         i = 0 ;
                         do
@@ -2231,7 +2231,7 @@ static char const * openFileDialogWinGuiA(
                 }
         }
 
-        if (lHResult==S_OK || lHResult==S_FALSE) 
+        if (lHResult==S_OK || lHResult==S_FALSE)
         {
                 CoUninitialize();
         }
@@ -2272,7 +2272,7 @@ static char const * selectFolderDialogWinGuiA(
 				lRetval = aoBuff;
         }
 
-        if (lHResult==S_OK || lHResult==S_FALSE) 
+        if (lHResult==S_OK || lHResult==S_FALSE)
         {
                 CoUninitialize();
         }
@@ -2378,7 +2378,7 @@ static int messageBoxWinConsole(
         char lDialogFile[MAX_PATH_OR_CMD];
         FILE * lIn;
         char lBuff [MAX_PATH_OR_CMD] = "";
-        
+
         strcpy( lDialogString , "dialog " ) ;
         if ( aTitle && strlen(aTitle) )
         {
@@ -2451,7 +2451,7 @@ static int messageBoxWinConsole(
 
         /*if (tinyfd_verbose) printf( "lDialogString: %s\n" , lDialogString ) ;*/
         system( lDialogString ) ;
-                
+
         if (!(lIn = fopen(lDialogFile, "r")))
         {
                 remove(lDialogFile);
@@ -2592,7 +2592,7 @@ static char const * saveFileDialogWinConsole(
                 strcat(lDialogString, aTitle) ;
                 strcat(lDialogString, "\" ") ;
         }
-        
+
         strcat(lDialogString, "--backtitle \"") ;
         strcat(lDialogString,
                 "tab: focus | /: populate | spacebar: fill text field | ok: TEXT FIELD ONLY") ;
@@ -2605,7 +2605,7 @@ static char const * saveFileDialogWinConsole(
                 strcpy(lPathAndFile, aDefaultPathAndFile);
                 replaceChr( lPathAndFile , '\\' , '/' ) ;
         }
-                
+
         /* dialog.exe needs at least one separator */
         if ( ! strchr(lPathAndFile, '/') )
         {
@@ -2670,7 +2670,7 @@ static char const * openFileDialogWinConsole(
                 strcpy(lFilterPatterns, aDefaultPathAndFile);
                 replaceChr( lFilterPatterns , '\\' , '/' ) ;
         }
-                
+
         /* dialog.exe needs at least one separator */
         if ( ! strchr(lFilterPatterns, '/') )
         {
@@ -2708,7 +2708,7 @@ static char const * selectFolderDialogWinConsole(
         char lDialogString [MAX_PATH_OR_CMD] ;
         char lString [MAX_PATH_OR_CMD] ;
         FILE * lIn ;
-        
+
         strcpy( lDialogString , "dialog " ) ;
         if ( aTitle && strlen(aTitle) )
         {
@@ -2797,7 +2797,7 @@ int tinyfd_messageBox(
                 if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"basicinput");return 0;}
                 if (!gWarningDisplayed && !tinyfd_forceConsole )
                 {
-                        gWarningDisplayed = 1; 
+                        gWarningDisplayed = 1;
                         printf("\n\n%s\n", gTitle);
                         printf("%s\n\n", tinyfd_needs);
                 }
@@ -2871,8 +2871,8 @@ int tinyfd_notifyPopup(
         char const * const aIconType ) /* "info" "warning" "error" */
 {
 #ifndef TINYFD_NOLIB
-        if ((!tinyfd_forceConsole || !( 
-                GetConsoleWindow() || 
+        if ((!tinyfd_forceConsole || !(
+                GetConsoleWindow() ||
                 dialogPresent()))
                 && ( !getenv("SSH_CLIENT") || getenv("DISPLAY") ) )
         {
@@ -2900,8 +2900,8 @@ char const * tinyfd_inputBox(
         DWORD mode = 0;
         HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
 
-        if ((!tinyfd_forceConsole || !( 
-                GetConsoleWindow() || 
+        if ((!tinyfd_forceConsole || !(
+                GetConsoleWindow() ||
                 dialogPresent()))
                 && ( !getenv("SSH_CLIENT") || getenv("DISPLAY") ) )
         {
@@ -2917,7 +2917,7 @@ char const * tinyfd_inputBox(
                 lBuff[0]='\0';
                 return inputBoxWinConsole(lBuff,aTitle,aMessage,aDefaultInput);
         }
-        else 
+        else
         {
       if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"basicinput");return (char const *)0;}
       lBuff[0]='\0';
@@ -3121,7 +3121,7 @@ char const * tinyfd_selectFolderDialog(
                 if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"basicinput");return (char const *)0;}
                 p = tinyfd_inputBox(aTitle, "Select folder","");
         }
-        
+
         if ( ! p || ! strlen( p ) || ! dirExists( p ) )
         {
                 return NULL ;
@@ -3224,7 +3224,7 @@ static int dirExists( char const * const aDirPath )
         return 1 ;
 }
 
-                                                                        
+
 static int detectPresence( char const * const aExecutable )
 {
         char lBuff [MAX_PATH_OR_CMD] ;
@@ -3257,14 +3257,14 @@ static char const * getVersion( char const * const aExecutable ) /*version must 
 	char lTestedString [MAX_PATH_OR_CMD] ;
 	FILE * lIn ;
 	char * lTmp ;
-		
+
     strcpy( lTestedString , aExecutable ) ;
     strcat( lTestedString , " --version" ) ;
 
     lIn = popen( lTestedString , "r" ) ;
         lTmp = fgets( lBuff , sizeof( lBuff ) , lIn ) ;
         pclose( lIn ) ;
-	
+
 	lTmp += strcspn(lTmp,"0123456789");
 	/* printf("lTmp:%s\n", lTmp); */
 	return lTmp ;
@@ -3317,7 +3317,7 @@ static int copyAndDetectPresence(char *aExecutable, char const * const path)
 static int isTerminalRunning(void)
 {
 	static int lIsTerminalRunning = -1 ;
-	if ( lIsTerminalRunning < 0 ) 
+	if ( lIsTerminalRunning < 0 )
 	{
 		lIsTerminalRunning = isatty(1);
 		if (tinyfd_verbose) printf("isTerminalRunning %d\n", lIsTerminalRunning );
@@ -3864,7 +3864,7 @@ static int osx9orBetter(void)
                         }
                 }
                 pclose( lIn ) ;
-                if (tinyfd_verbose) printf("Osx10 = %d, %d = %s\n", lOsx9orBetter, V, lBuff) ; 
+                if (tinyfd_verbose) printf("Osx10 = %d, %d = %s\n", lOsx9orBetter, V, lBuff) ;
         }
         return lOsx9orBetter ;
 }
@@ -4039,18 +4039,18 @@ void tinyfd_beep(void)
                         strcpy( lDialogString , "osascript -e 'tell application \"System Events\" to beep'") ;
                 }
         }
-        else if ( pactlPresent() ) 
+        else if ( pactlPresent() )
         {
                 signal(SIGINT, sigHandler);
                 /*strcpy( lDialogString , "pactl load-module module-sine frequency=440;sleep .3;pactl unload-module module-sine" ) ;*/
                 strcpy( lDialogString , "thnum=$(pactl load-module module-sine frequency=440);sleep .3;pactl unload-module $thnum" ) ;
         }
-        else if ( speakertestPresent() ) 
+        else if ( speakertestPresent() )
         {
                 /*strcpy( lDialogString , "timeout -k .3 .3 speaker-test --frequency 440 --test sine > /dev/tty" ) ;*/
                 strcpy( lDialogString , "( speaker-test -t sine -f 440 > /dev/tty )& pid=$!;sleep .3; kill -9 $pid" ) ;
         }
-        else if ( beepexePresent() ) 
+        else if ( beepexePresent() )
         {
                 strcpy( lDialogString , "beep.exe 440 300" ) ;
         }
@@ -4143,7 +4143,7 @@ int tinyfd_messageBox(
                 else if ( aDialogType && ! strcmp( "yesno" , aDialogType ) )
                 {
                         strcat( lDialogString ,"buttons {\"No\", \"Yes\"} " ) ;
-                        if (aDefaultButton) 
+                        if (aDefaultButton)
                         {
                                 strcat( lDialogString ,"default button \"Yes\" " ) ;
                         }
@@ -4156,7 +4156,7 @@ int tinyfd_messageBox(
                 else if ( aDialogType && ! strcmp( "yesnocancel" , aDialogType ) )
                 {
                         strcat( lDialogString ,"buttons {\"No\", \"Yes\", \"Cancel\"} " ) ;
-                        switch (aDefaultButton) 
+                        switch (aDefaultButton)
                         {
                                 case 1: strcat( lDialogString ,"default button \"Yes\" " ) ; break;
                                 case 2: strcat( lDialogString ,"default button \"No\" " ) ; break;
@@ -4280,7 +4280,7 @@ int tinyfd_messageBox(
                                 strcat(lDialogString, " --attach=$(xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2)"); /* contribution: Paul Rouget */
                         }
                 }
-                strcat(lDialogString, " --"); 
+                strcat(lDialogString, " --");
 
                 if ( aDialogType && ! strcmp( "okcancel" , aDialogType ) )
                 {
@@ -4307,13 +4307,13 @@ int tinyfd_messageBox(
                 {
                     strcat( lDialogString , "info" ) ;
                 }
-                if ( aTitle && strlen(aTitle) ) 
+                if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, " --title=\"") ;
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\"") ;
                 }
-                if ( aMessage && strlen(aMessage) ) 
+                if ( aMessage && strlen(aMessage) )
                 {
                         strcat(lDialogString, " --no-wrap --text=\"") ;
                         strcat(lDialogString, aMessage) ;
@@ -4355,10 +4355,10 @@ int tinyfd_messageBox(
                 {
                         strcat( lDialogString , " -i" ) ;  /* for osx without console */
                 }
-                
+
                 strcat( lDialogString ,
 " -S -c \"import Tkinter,tkMessageBox;root=Tkinter.Tk();root.withdraw();");
-                
+
                 if ( isDarwin( ) )
                 {
                         strcat( lDialogString ,
@@ -4417,7 +4417,7 @@ frontmost of process \\\"Python\\\" to true' ''');");
                 {
                                 strcat( lDialogString , "info" ) ;
                 }
-                
+
                 strcat(lDialogString, "',") ;
                 if ( aTitle && strlen(aTitle) )
                 {
@@ -4654,7 +4654,7 @@ else :\n\tprint(1)\n\"" ) ;
 
                 if ( !xdialogPresent() && !gdialogPresent() )
                 {
-                        if ( aDialogType && ( !strcmp( "okcancel" , aDialogType ) || !strcmp( "yesno" , aDialogType ) 
+                        if ( aDialogType && ( !strcmp( "okcancel" , aDialogType ) || !strcmp( "yesno" , aDialogType )
                                 || !strcmp( "yesnocancel" , aDialogType ) ) )
                         {
                                 strcat(lDialogString, "--backtitle \"") ;
@@ -4951,7 +4951,7 @@ tinyfdRes=$(cat /tmp/tinyfd.txt);echo $tinyfdBool$tinyfdRes") ;
                         }
                         printf("press enter to continue "); fflush(stdout);
                         getchar() ;
-                        printf("\n\n"); 
+                        printf("\n\n");
                         lResult = 1 ;
                 }
                 tcsetattr(0, TCSANOW, &infoOri);
@@ -4978,10 +4978,10 @@ tinyfdRes=$(cat /tmp/tinyfd.txt);echo $tinyfdBool$tinyfdRes") ;
         }
         /* printf( "lBuff1: %s len: %lu \n" , lBuff , strlen(lBuff) ) ; */
 
-        if (aDialogType && !strcmp("yesnocancel", aDialogType)) 
+        if (aDialogType && !strcmp("yesnocancel", aDialogType))
         {
                 if ( lBuff[0]=='1' )
-                { 
+                {
                         if ( !strcmp( lBuff+1 , "Yes" )) strcpy(lBuff,"1");
                         else if ( !strcmp( lBuff+1 , "No" )) strcpy(lBuff,"2");
                 }
@@ -5039,7 +5039,7 @@ int tinyfd_notifyPopup(
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\" ") ;
                 }
-                
+
                 strcat( lDialogString, "' -e 'end try'") ;
                 if ( ! osx9orBetter() ) strcat( lDialogString, " -e 'end tell'") ;
         }
@@ -5094,11 +5094,11 @@ int tinyfd_notifyPopup(
                         strcpy( lDialogString , "qarma" ) ;
                 }
 
-                strcat( lDialogString , " --notification"); 
+                strcat( lDialogString , " --notification");
 
                 if ( aIconType && strlen( aIconType ) )
                 {
-                        strcat( lDialogString , " --window-icon '"); 
+                        strcat( lDialogString , " --window-icon '");
                         strcat( lDialogString , aIconType ) ;
                         strcat( lDialogString , "'" ) ;
                 }
@@ -5395,17 +5395,17 @@ char const * tinyfd_inputBox(
                 {
                 strcat( lDialogString , " -i" ) ;  /* for osx without console */
                 }
-                
+
                 strcat( lDialogString ,
 " -S -c \"import Tkinter,tkSimpleDialog;root=Tkinter.Tk();root.withdraw();");
-                
+
                 if ( isDarwin( ) )
                 {
                         strcat( lDialogString ,
 "import os;os.system('''/usr/bin/osascript -e 'tell app \\\"Finder\\\" to set \
 frontmost of process \\\"Python\\\" to true' ''');");
                 }
-                
+
                 strcat( lDialogString ,"res=tkSimpleDialog.askstring(" ) ;
                 if ( aTitle && strlen(aTitle) )
                 {
@@ -5599,7 +5599,7 @@ frontmost of process \\\"Python\\\" to true' ''');");
                         strcat( lDialogString, aTitle) ;
                         strcat( lDialogString , "\";echo;" ) ;
                 }
-                
+
                 strcat( lDialogString , "echo \"" ) ;
                 if ( aMessage && strlen(aMessage) )
                 {
@@ -5876,18 +5876,18 @@ char const * tinyfd_saveFileDialog(
                 }
                 strcat(lDialogString, " --file-selection --save --confirm-overwrite" ) ;
 
-                if ( aTitle && strlen(aTitle) ) 
+                if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, " --title=\"") ;
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\"") ;
                 }
-                if ( aDefaultPathAndFile && strlen(aDefaultPathAndFile) ) 
+                if ( aDefaultPathAndFile && strlen(aDefaultPathAndFile) )
                 {
                         strcat(lDialogString, " --filename=\"") ;
                         strcat(lDialogString, aDefaultPathAndFile) ;
                         strcat(lDialogString, "\"") ;
-                }               
+                }
                 if ( aNumOfFilterPatterns > 0 )
                 {
                         strcat( lDialogString , " --file-filter='" ) ;
@@ -6143,7 +6143,7 @@ char const * tinyfd_saveFileDialog(
     return lBuff ;
 }
 
-                 
+
 /* in case of multiple files, the separator is | */
 char const * tinyfd_openFileDialog(
     char const * const aTitle , /* NULL or "" */
@@ -6332,7 +6332,7 @@ char const * tinyfd_openFileDialog(
                 }
                 if ( aNumOfFilterPatterns > 0 )
                 {
-                        strcat( lDialogString , " --file-filter='" ) ; 
+                        strcat( lDialogString , " --file-filter='" ) ;
                         if ( aSingleFilterDescription && strlen(aSingleFilterDescription) )
                         {
                                 strcat( lDialogString , aSingleFilterDescription ) ;
@@ -6707,13 +6707,13 @@ char const * tinyfd_selectFolderDialog(
                 }
                 strcat( lDialogString , " --file-selection --directory" ) ;
 
-                if ( aTitle && strlen(aTitle) ) 
+                if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, " --title=\"") ;
                         strcat(lDialogString, aTitle) ;
                         strcat(lDialogString, "\"") ;
                 }
-                if ( aDefaultPath && strlen(aDefaultPath) ) 
+                if ( aDefaultPath && strlen(aDefaultPath) )
                 {
                         strcat(lDialogString, " --filename=\"") ;
                         strcat(lDialogString, aDefaultPath) ;
@@ -6828,7 +6828,7 @@ frontmost of process \\\"Python\\\" to true' ''');");
                 {
                         strcat(lDialogString, "./") ;
                 }
-                
+
                 if ( lWasGraphicDialog )
                 {
                         strcat(lDialogString, "\" 0 60 ) 2>&1 ") ;
@@ -6921,13 +6921,13 @@ char const * tinyfd_colorChooser(
                 if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"applescript");return (char const *)1;}
                 lWasOsascript = 1 ;
                 strcpy( lDialogString , "osascript");
-                                
-                if ( ! osx9orBetter() ) 
+
+                if ( ! osx9orBetter() )
                 {
                         strcat( lDialogString , " -e 'tell application \"System Events\"' -e 'Activate'");
                         strcat( lDialogString , " -e 'try' -e 'set mycolor to choose color default color {");
                 }
-                else 
+                else
                 {
                         strcat( lDialogString ,
 " -e 'try' -e 'tell app (path to frontmost application as Unicode text) \
@@ -7006,7 +7006,7 @@ to set mycolor to choose color default color {");
                 strcat( lDialogString , " --color-selection --show-palette" ) ;
                 sprintf( lDialogString + strlen(lDialogString), " --color=%s" , lpDefaultHexRGB ) ;
 
-                if ( aTitle && strlen(aTitle) ) 
+                if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, " --title=\"") ;
                         strcat(lDialogString, aTitle) ;
@@ -7037,7 +7037,7 @@ to set mycolor to choose color default color {");
                 {
                 strcat( lDialogString , " -i" ) ;  /* for osx without console */
                 }
-                
+
                 strcat( lDialogString ,
 " -S -c \"import Tkinter,tkColorChooser;root=Tkinter.Tk();root.withdraw();");
 
@@ -7120,7 +7120,7 @@ frontmost of process \\\"Python\\\" to true' ''');");
     {
         lBuff[strlen( lBuff ) -1] = '\0' ;
     }
-    
+
         if ( lWasZenity3 )
     {
                 if ( lBuff[0] == '#' )
@@ -7170,7 +7170,7 @@ char const * tinyfd_arrayDialog(
         int const aNumOfColumns , /* 2 */
         char const * const * const aColumns , /* {"Column 1","Column 2"} */
         int const aNumOfRows , /* 2 */
-        char const * const * const aCells ) 
+        char const * const * const aCells )
                 /* {"Row1 Col1","Row1 Col2","Row2 Col1","Row2 Col2"} */
 {
         static char lBuff [MAX_PATH_OR_CMD] ;
@@ -7440,4 +7440,3 @@ tinyfd_messageBox("The selected hexcolor is",
 #endif
 
 #endif /* USE_TINYFILEDIALOGS */
-


### PR DESCRIPTION
The changes leave standard MinGW build process intact.

My IDE automatically cleared a bunch of trailing whitespace. This clutters the diff, so please view with `hide whitespace changes` enabled. EDIT: if these changes are contributing to the concern about diverging from upstream, I can edit the history on my fork to leave in the trailing spaces (upon request)