### PR TITLE
Initialize some variables to prevent reading garbage

### DIFF
--- a/src/core/encoding.c
+++ b/src/core/encoding.c
@@ -517,7 +517,7 @@ static const letter_code* search_utf8_table(const from_utf8_lookup *key, const f
 static const letter_code* get_letter_code_for_utf8(const char *c, int *num_bytes, int *is_accent)
 {
     static letter_code single_char = {0, 1};
-    from_utf8_lookup key;
+    from_utf8_lookup key = {0, NULL};
     if (is_accent) *is_accent = 0;
     const uint8_t *uc = (const uint8_t *) c;
 

--- a/src/figuretype/enemy.c
+++ b/src/figuretype/enemy.c
@@ -49,7 +49,7 @@ static void enemy_initial(figure *f, formation *m)
         f->type == FIGURE_ENEMY51_SPEAR || f->type == FIGURE_ENEMY52_MOUNTED_ARCHER) {
         // missile throwers
         f->wait_ticks_missile++;
-        map_point tile;
+        map_point tile = {0, 0};
         if (f->wait_ticks_missile > figure_properties_for_type(f->type)->missile_delay) {
             f->wait_ticks_missile = 0;
             if (figure_combat_get_missile_target_for_enemy(f, 10, city_figures_soldiers() < 4, &tile)) {


### PR DESCRIPTION
Found by clang-analyzer. 