### PR TITLE
Fix switch compilation with latest toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,6 +631,8 @@ elseif(SWITCH_BUILD)
         modplug
         mpg123
         FLAC
+        opusfile
+        opus
         ogg
         jpeg
         png


### PR DESCRIPTION
Newest toolchain version of SDL_mixer requires linking with opusfile and opus. 