### PR TITLE
Fix build with SDL 2.0.10

### DIFF
--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -368,7 +368,10 @@ static int init_sdl(void)
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not initialize SDL: %s", SDL_GetError());
         return 0;
     }
-#if SDL_VERSION_ATLEAST(2, 0, 4)
+#if SDL_VERSION_ATLEAST(2, 0, 10)
+    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "1");
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
+#elif SDL_VERSION_ATLEAST(2, 0, 4)
     SDL_SetHint(SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1");
 #endif
     SDL_Log("SDL initialized");

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -369,8 +369,8 @@ static int init_sdl(void)
         return 0;
     }
 #if SDL_VERSION_ATLEAST(2, 0, 10)
-    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "1");
-    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
+    SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 #elif SDL_VERSION_ATLEAST(2, 0, 4)
     SDL_SetHint(SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1");
 #endif


### PR DESCRIPTION
SDL 2.0.10 removed `SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH` and introduced `SDL_HINT_MOUSE_TOUCH_EVENTS` and `SDL_HINT_TOUCH_MOUSE_EVENTS`.