### PR TITLE
Change Travis configuration to use the most recent version of SDL (2.0.10).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ matrix:
   include:
   - os: linux
     compiler: gcc
-    env: SDL_LIB=SDL2-2.0.9 SDL_MIXER_LIB=SDL2_mixer-2.0.4 RUN_CODECOV=1
+    env: SDL_LIB=SDL2-2.0.10 SDL_MIXER_LIB=SDL2_mixer-2.0.4 RUN_CODECOV=1
   - os: linux
     compiler: gcc
     env: SDL_LIB=SDL2-2.0.0 SDL_MIXER_LIB=SDL2_mixer-2.0.0
   - os: linux
     compiler: clang
-    env: SDL_LIB=SDL2-2.0.9 SDL_MIXER_LIB=SDL2_mixer-2.0.4
+    env: SDL_LIB=SDL2-2.0.10 SDL_MIXER_LIB=SDL2_mixer-2.0.4
   - os: linux
     dist: xenial # Oldest still-supported LTS right now against which the AppImage is built. Update this to the next LTS when support drops.
     name: Linux AppImage
@@ -22,7 +22,7 @@ matrix:
       - docker
   - os: osx
     compiler: clang
-    env: SDL_LIB=SDL2-2.0.9 SDL_MIXER_LIB=SDL2_mixer-2.0.4 BUILD_TARGET=mac DEPLOY=mac
+    env: SDL_LIB=SDL2-2.0.10 SDL_MIXER_LIB=SDL2_mixer-2.0.4 BUILD_TARGET=mac DEPLOY=mac
   - os: linux
     name: PS Vita
     env: BUILD_TARGET=vita DEPLOY=vita


### PR DESCRIPTION
While Appveyor had been updated, Travis was left forgotten. So now that's fixed.