### PR TITLE
[SWITCH] Fix missing mouse pointers

### DIFF
--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -481,11 +481,12 @@ static void setup(const julius_args *args)
 
     char title[100];
     encoding_to_utf8(lang_get_string(9, 0), title, 100, 0);
-    platform_init_cursors(args->cursor_scale_percentage);
     if (!platform_screen_create(title, args->display_scale_percentage)) {
         SDL_Log("Exiting: SDL create window failed");
         exit(-2);
     }
+    // this has to come after platform_screen_create, otherwise it fails on Nintendo Switch
+    platform_init_cursors(args->cursor_scale_percentage);
 
     int game_init_result = game_init();
     if (game_init_result == GAME_INIT_ERROR) {

--- a/src/platform/switch/cursor.c
+++ b/src/platform/switch/cursor.c
@@ -21,7 +21,7 @@ static SDL_Texture *init_cursor(const cursor *c)
 {
     SDL_Texture *tex = SDL_CreateTexture(SDL.renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STATIC, CURSOR_SIZE, CURSOR_SIZE);
 
-    uint32_t pixels[CURSOR_SIZE * CURSOR_SIZE];
+    uint32_t pixels[CURSOR_SIZE * CURSOR_SIZE] = { 0 };
 
     for (int y = 0; y < c->height; y++) {
         for (int x = 0; x < c->width; x++) {


### PR DESCRIPTION
This fixes the missing mouse pointers in hidpi branch. It also removes garbage pixels in the pointers that appeared because the new pointer definitions can have smaller size than the pointer texture size on Switch.