### PR TITLE
Fix all compiler warnings

### DIFF
--- a/ext/tinyfiledialogs/tinyfiledialogs.c
+++ b/ext/tinyfiledialogs/tinyfiledialogs.c
@@ -3919,7 +3919,7 @@ static int python3Present(void)
 static int tkinter2Present(void)
 {
     static int lTkinter2Present = -1 ;
-        char lPythonCommand[256];
+        char lPythonCommand[300];
         char lPythonParams[256] =
 "-S -c \"try:\n\timport Tkinter;\nexcept:\n\tprint 0;\"";
 
@@ -3941,7 +3941,7 @@ static int tkinter2Present(void)
 static int tkinter3Present(void)
 {
         static int lTkinter3Present = -1 ;
-        char lPythonCommand[256];
+        char lPythonCommand[300];
         char lPythonParams[256] =
                 "-S -c \"try:\n\timport tkinter;\nexcept:\n\tprint(0);\"";
 
@@ -3962,7 +3962,7 @@ static int tkinter3Present(void)
 static int pythonDbusPresent(void)
 {
     static int lDbusPresent = -1 ;
-        char lPythonCommand[256];
+        char lPythonCommand[300];
         char lPythonParams[256] =
 "-c \"try:\n\timport dbus;bus=dbus.SessionBus();\
 notif=bus.get_object('org.freedesktop.Notifications','/org/freedesktop/Notifications');\

--- a/src/core/dir.c
+++ b/src/core/dir.c
@@ -46,8 +46,6 @@ static const char *filename_to_utf8(const wchar_t *str)
 #define CURRENT_DIR "."
 #endif
 
-#define MAX_FILE_NAME_BUFFER (FILE_NAME_MAX * 2)
-
 static dir_listing listing;
 static int listing_initialized = 0;
 
@@ -55,7 +53,7 @@ static void clear_dir_listing(void)
 {
     if (!listing_initialized) {
         for (int i = 0; i < DIR_MAX_FILES; i++) {
-            listing.files[i] = malloc(MAX_FILE_NAME_BUFFER * sizeof(char));
+            listing.files[i] = malloc(FILE_NAME_MAX * sizeof(char));
         }
         listing_initialized = 1;
     }
@@ -82,7 +80,7 @@ const dir_listing *dir_find_files_with_extension(const char *extension)
     while ((entry = fs_dir_read(d)) && listing.num_files < DIR_MAX_FILES) {
         const char *name = dir_entry_name(entry);
         if (file_has_extension(name, extension)) {
-            strncpy(listing.files[listing.num_files], name, MAX_FILE_NAME_BUFFER);
+            strncpy(listing.files[listing.num_files], name, FILE_NAME_MAX);
             listing.files[listing.num_files][FILE_NAME_MAX - 1] = 0;
             ++listing.num_files;
         }

--- a/src/core/dir.c
+++ b/src/core/dir.c
@@ -46,6 +46,8 @@ static const char *filename_to_utf8(const wchar_t *str)
 #define CURRENT_DIR "."
 #endif
 
+#define MAX_FILE_NAME_BUFFER (FILE_NAME_MAX * 2)
+
 static dir_listing listing;
 static int listing_initialized = 0;
 
@@ -53,7 +55,7 @@ static void clear_dir_listing(void)
 {
     if (!listing_initialized) {
         for (int i = 0; i < DIR_MAX_FILES; i++) {
-            listing.files[i] = malloc(FILE_NAME_MAX * sizeof(char));
+            listing.files[i] = malloc(MAX_FILE_NAME_BUFFER * sizeof(char));
         }
         listing_initialized = 1;
     }
@@ -80,7 +82,7 @@ const dir_listing *dir_find_files_with_extension(const char *extension)
     while ((entry = fs_dir_read(d)) && listing.num_files < DIR_MAX_FILES) {
         const char *name = dir_entry_name(entry);
         if (file_has_extension(name, extension)) {
-            strncpy(listing.files[listing.num_files], name, FILE_NAME_MAX - 1);
+            strncpy(listing.files[listing.num_files], name, MAX_FILE_NAME_BUFFER);
             listing.files[listing.num_files][FILE_NAME_MAX - 1] = 0;
             ++listing.num_files;
         }

--- a/src/core/file.h
+++ b/src/core/file.h
@@ -14,7 +14,7 @@
  * @li Extension parameters are expected to be 3 chars, without leading dot
  */
 
-#define FILE_NAME_MAX 200
+#define FILE_NAME_MAX 300
 
 /**
  * Wrapper for fopen converting filename to path in current working directory

--- a/src/game/file_io.c
+++ b/src/game/file_io.c
@@ -606,7 +606,7 @@ static void savegame_read_from_file(FILE *fp)
         if (piece->compressed) {
             result = read_compressed_chunk(fp, piece->buf.data, piece->buf.size);
         } else {
-            result = (fread(piece->buf.data, 1, piece->buf.size, fp) == piece->buf.size);
+            result = fread(piece->buf.data, 1, piece->buf.size, fp) == piece->buf.size;
         }
         if (!result) {
             return;

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -215,6 +215,7 @@ static void handle_mouse_button(SDL_MouseButtonEvent *event, int is_down)
     }
 }
 
+#ifndef __SWITCH__
 static void handle_window_event(SDL_WindowEvent *event, int *window_active)
 {
     switch (event->event) {
@@ -225,27 +226,28 @@ static void handle_window_event(SDL_WindowEvent *event, int *window_active)
             mouse_set_inside_window(0);
             break;
         case SDL_WINDOWEVENT_SIZE_CHANGED:
-            SDL_Log("Window resized to %d x %d", event->data1, event->data2);
+            SDL_Log("Window resized to %d x %d", (int) event->data1, (int) event->data2);
             platform_screen_resize(event->data1, event->data2);
             break;
         case SDL_WINDOWEVENT_RESIZED:
-            SDL_Log("System resize to %d x %d", event->data1, event->data2);
+            SDL_Log("System resize to %d x %d", (int) event->data1, (int) event->data2);
             break;
         case SDL_WINDOWEVENT_MOVED:
-            SDL_Log("Window move to coordinates x: %d y: %d\n", event->data1, event->data2);
+            SDL_Log("Window move to coordinates x: %d y: %d\n", (int) event->data1, (int) event->data2);
             platform_screen_move(event->data1, event->data2);
             break;
 
         case SDL_WINDOWEVENT_SHOWN:
-            SDL_Log("Window %d shown", event->windowID);
+            SDL_Log("Window %d shown", (unsigned int) event->windowID);
             *window_active = 1;
             break;
         case SDL_WINDOWEVENT_HIDDEN:
-            SDL_Log("Window %d hidden", event->windowID);
+            SDL_Log("Window %d hidden", (unsigned int) event->windowID);
             *window_active = 0;
             break;
     }
 }
+#endif
 
 static void handle_event(SDL_Event *event, int *active, int *quit)
 {

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -287,7 +287,7 @@ static void button_scroll(int is_down, int num_lines)
 static void button_select_file(int index, int param2)
 {
     if (index < data.file_list->num_files) {
-        strncpy(data.selected_file, data.file_list->files[data.scroll_position + index], FILE_NAME_MAX);
+        strncpy(data.selected_file, data.file_list->files[data.scroll_position + index], FILE_NAME_MAX - 1);
         encoding_from_utf8(data.selected_file, data.typed_name, FILE_NAME_MAX);
         file_remove_extension(data.typed_name);
         keyboard_refresh();

--- a/test/sav/run.c
+++ b/test/sav/run.c
@@ -53,7 +53,6 @@ static int run_autopilot(const char *input_saved_game, const char *output_saved_
     printf("Running autopilot: %s --> %s in %d ticks\n", input_saved_game, output_saved_game, ticks_to_run);
     signal(SIGSEGV, handler);
 
-    chdir("data/sav");
     if (!game_pre_init()) {
         printf("Unable to run Game_preInit\n");
         return 1;
@@ -66,8 +65,11 @@ static int run_autopilot(const char *input_saved_game, const char *output_saved_
 
     if (!game_file_load_saved_game(input_saved_game)) {
         char wd[500];
-        getcwd(wd, 500);
-        printf("Unable to load saved game from %s\n", wd);
+        if (getcwd(wd, 500)) {
+            printf("Unable to load saved game from %s\n", wd);
+        } else {
+            printf("Unable to load saved game\n");
+        }
         return 3;
     }
     run_ticks(ticks_to_run);

--- a/test/sav/sav_compare.c
+++ b/test/sav/sav_compare.c
@@ -293,7 +293,7 @@ static int unpack(const char *filename, unsigned char *buffer)
         if (save_game_parts[i].compressed) {
             result = read_compressed_chunk(fp, &buffer[offset], save_game_parts[i].length_in_bytes);
         } else {
-            result = (fread(&buffer[offset], 1, save_game_parts[i].length_in_bytes, fp) == save_game_parts[i].length_in_bytes);
+            result = fread(&buffer[offset], 1, save_game_parts[i].length_in_bytes, fp) == save_game_parts[i].length_in_bytes;
         }
         offset += save_game_parts[i].length_in_bytes;
         if (!result) {


### PR DESCRIPTION
Except for two on the Switch build which are related to DevKitPro header files.

Tested: Windows MSVC 2019, all AppImage and Travis builds. Please test for warnings in specific compilers.