### PR TITLE
Fix bug where sometimes tiles would stay red after deletion.

### DIFF
--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -474,7 +474,7 @@ void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_
         city_view_foreach_valid_map_tile(
             draw_elevated_figures,
             draw_hippodrome_ornaments,
-            0
+            clear_deleted
         );
     } else {
         city_view_foreach_map_tile(deletion_draw_terrain_top);


### PR DESCRIPTION
@411752230:
> Just found a small problem in-game. Start a new game with a bigger map, deleting all objects at one go by clear land, you will see some rocks as well as some other objects become red before you click the clear land button again with all the red objects turning to normal.

Fixed by this PR.