### PR TITLE
Improve CMake to allow SDL and SDL_mixer to be detected from folder ext/SDL2

### DIFF
--- a/.ci_scripts/install_sdl.sh
+++ b/.ci_scripts/install_sdl.sh
@@ -37,22 +37,25 @@ function get_sdl_lib_url {
 
 function install_sdl_lib {
   local LIB=$1
-  if [ -d $LIB/build ]
+  if [ ! "$(ls -A $LIB)" ]
   then
-    cp -r $LIB $LIB-final
-    cd $LIB-final/build
-  else
     get_sdl_lib_url $LIB "tar.gz"
     travis_retry curl -L $SDL_LIB_URL | tar xz
     cd $LIB
     mkdir build
     cd build
-    ../configure
+    SDL2_CONFIG="${SDL2_CONFIG}" ../configure --prefix=$(pwd)/..
+    make
+    SDL2_CONFIG="$(pwd)/sdl2-config"
+    cp -r build/.libs ../lib
+    cd ..
+    mv include SDL2 2>/dev/null
+    mkdir include
+    mv SDL2 include/ 2>/dev/null
+    cp SDL_mixer.h include/ 2>/dev/null
+    cd ..
   fi
-  make
-  sudo make install
-
-  cd ../..
+  ln -s "$(pwd)/$LIB" "$(pwd)/ext/SDL2/"
 }
 
 function install_sdl_macos {

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ res/version.txt
 res/julius.icns
 /CMakeSettings.json
 out/
+ext/SDL2/*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@ if(VITA_BUILD AND SWITCH_BUILD)
     message(FATAL_ERROR "Cannot build with -DVITA_BUILD=ON and -DSWITCH_BUILD=ON at the same time")
 endif()
 
-option(VITA_BUILD "Build for the PlayStation Vita handheld game console." OFF)
-cmake_dependent_option(SWITCH_BUILD "Build for the Nintendo Switch handheld game console." OFF "NOT VITA_BUILD" OFF)
+option(DRAW_FPS "Draw FPS on the top left corner of the window." OFF)
+cmake_dependent_option(VITA_BUILD "Build for the PlayStation Vita handheld game console." OFF "NOT MSVC" OFF)
+cmake_dependent_option(SWITCH_BUILD "Build for the Nintendo Switch handheld game console." OFF "NOT MSVC; NOT VITA_BUILD" OFF)
 
 if(VITA_BUILD AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
     if(DEFINED ENV{VITASDK})
@@ -537,6 +538,28 @@ add_executable(julius
     ${PROJECT_SOURCE_DIR}/res/julius.rc
     ${MACOSX_FILES}
 )
+
+function(GET_SDL_EXT_DIR result module)
+    if(NOT module STREQUAL "")
+        set(module "_${module}")
+    endif()
+    set(SDL_LOCATION ${PROJECT_SOURCE_DIR}/ext/SDL2)
+    file(GLOB children
+        RELATIVE ${SDL_LOCATION}
+        CONFIGURE_DEPENDS
+        ${SDL_LOCATION}/SDL${module}
+        ${SDL_LOCATION}/SDL2${module}
+        ${SDL_LOCATION}/SDL${module}-*
+        ${SDL_LOCATION}/SDL2${module}-*
+    )
+    foreach(child ${children})
+        if(IS_DIRECTORY "${SDL_LOCATION}/${child}")
+            set(${result} "${SDL_LOCATION}/${child}" PARENT_SCOPE)
+            set(internal_result "${SDL_LOCATION}/${child}")
+            break()
+        endif()
+    endforeach()
+endfunction()
 
 find_package(SDL2 REQUIRED)
 find_package(SDL2_mixer REQUIRED)

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -75,6 +75,14 @@ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 GET_SDL_EXT_DIR(SDL_EXT_DIR "")
 
+if(MINGW AND DEFINED SDL_EXT_DIR)
+    if(SDL2_ARCH_64)
+	  set(SDL_MINGW_EXT_DIR "${SDL_EXT_DIR}/x86_64-w64-mingw32")
+    else()
+	  set(SDL_MINGW_EXT_DIR "${SDL_EXT_DIR}/i686-w64-mingw32")
+	endif()
+endif()
+
 SET(SDL2_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
@@ -85,6 +93,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/csw # Blastwave
 	/opt
 	${SDL_EXT_DIR}
+	${SDL_MINGW_EXT_DIR}
 )
 
 if (VITA)

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -73,6 +73,8 @@ else()
   set(SDL2_PROCESSOR_ARCH "x86")
 endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
+GET_SDL_EXT_DIR(SDL_EXT_DIR "")
+
 SET(SDL2_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
@@ -82,6 +84,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
+	${SDL_EXT_DIR}
 )
 
 if (VITA)

--- a/cmake/FindSDL2_mixer.cmake
+++ b/cmake/FindSDL2_mixer.cmake
@@ -42,6 +42,14 @@ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 GET_SDL_EXT_DIR(SDL_EXT_DIR "mixer")
 
+if(MINGW AND DEFINED SDL_EXT_DIR)
+    if(SDL2_ARCH_64)
+	  set(SDL_MINGW_EXT_DIR "${SDL_EXT_DIR}/x86_64-w64-mingw32")
+    else()
+	  set(SDL_MINGW_EXT_DIR "${SDL_EXT_DIR}/i686-w64-mingw32")
+	endif()
+endif()
+
 SET(SDL2_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
@@ -52,6 +60,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/csw # Blastwave
 	/opt
     ${SDL_EXT_DIR}
+    ${SDL_MINGW_EXT_DIR}
 )
 
 if (VITA)

--- a/cmake/FindSDL2_mixer.cmake
+++ b/cmake/FindSDL2_mixer.cmake
@@ -40,6 +40,8 @@ else()
   set(SDL2_PROCESSOR_ARCH "x86")
 endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
+GET_SDL_EXT_DIR(SDL_EXT_DIR "mixer")
+
 SET(SDL2_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
@@ -49,6 +51,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
+    ${SDL_EXT_DIR}
 )
 
 if (VITA)


### PR DESCRIPTION
Allows travis to build julius without requiring make install, makng builds faster.

Also allows not having to set CMAKE_PREFIX_PATH in MSVC/MinGW, as long as the SDL libraries are saved to ext/SDL2.

In order for travis to work, its cache must first be deleted.