### PR TITLE
Vita: Remove preloading of SMK videos

### DIFF
--- a/src/graphics/video.c
+++ b/src/graphics/video.c
@@ -46,13 +46,8 @@ static int load_smk(const char *filename)
         return 0;
     }
     FILE *fp = file_open(path, "rb");
-#ifdef __vita__
-    // Vita file i/o is too slow to play videos smoothly from disk, so pre-load
-    // the pre-loading causes a short pause before video starts
-    data.s = smacker_open(fp, SMACKER_MODE_MEMORY);
-#else
     data.s = smacker_open(fp, SMACKER_MODE_DISK);
-#endif
+
     if (!data.s) {
         // smacker_open() closes the stream on error: no need to close fp
         return 0;


### PR DESCRIPTION
https://github.com/bvschaik/julius/pull/208 decreased the performance / IO requirements for watching SMK videos. With these changes, the video playback on the Vita is smooth enough and doesn't need preload anymore.