### PR TITLE
Game speed is now displayed (#229)

### DIFF
--- a/src/city/warning.c
+++ b/src/city/warning.c
@@ -5,6 +5,7 @@
 #include "core/string.h"
 #include "core/time.h"
 #include "game/settings.h"
+#include <stdio.h>
 
 #define MAX_WARNINGS 5
 #define MAX_TEXT 100
@@ -80,4 +81,17 @@ void city_warning_clear_outdated(void)
             warnings[i].in_use = 0;
         }
     }
+}
+
+void city_warning_game_speed(void)
+{
+    const uint8_t *langText = lang_get_string(45, 2);
+    struct warning *w = new_warning();
+    if (!w) {
+        return;
+    }
+    w->in_use = 1;
+    // 15 seconds is a long time to display the game speed
+    w->time = time_get_millis() - TIMEOUT_MS * 0.9;
+    sprintf((char*)w->text, "%s %d%%", langText, setting_game_speed());
 }

--- a/src/city/warning.h
+++ b/src/city/warning.h
@@ -67,5 +67,6 @@ const uint8_t *city_warning_get(int id);
 
 void city_warning_clear_all(void);
 void city_warning_clear_outdated(void);
+void city_warning_game_speed(void);
 
 #endif // CITY_WARNING_H

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -37,6 +37,8 @@ static void change_game_speed(int is_down)
         } else {
             setting_increase_game_speed();
         }
+        city_warning_clear_all();
+        city_warning_game_speed();
     }
 }
 
@@ -75,6 +77,9 @@ static void toggle_pause(void)
     if (window_is(WINDOW_CITY)) {
         game_state_toggle_paused();
         city_warning_clear_all();
+        if (!game_state_is_paused()) {
+            city_warning_game_speed();
+        }
     }
 }
 


### PR DESCRIPTION
Added game speed "warning" message after an unpause event and after the hotkeys '[' ']' are pressed.

![Screenshot from 2020-01-18 14-35-03](https://user-images.githubusercontent.com/24961694/72669462-e20a7000-39ff-11ea-8702-573b2c669eb7.png)
