### PR TITLE
Add logging on failure to load a music file

### DIFF
--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -128,8 +128,13 @@ int sound_device_play_music(const char *filename)
         #endif
 
         music = Mix_LoadMUS(resolved_filename);
-        if (music) {
-            Mix_PlayMusic(music, -1);
+        if (!music) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO, "Error opening music file '%s'. Reason: %s", resolved_filename, Mix_GetError());
+        } else {
+            if (Mix_PlayMusic(music, -1) == -1) {
+                music = 0;
+                SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO, "Error playing music file '%s'. Reason: %s", resolved_filename, Mix_GetError());
+            }
         }
 
         #ifdef __vita__


### PR DESCRIPTION
When a music file exists but can't be loaded or played, a warning will be added to the log explaining the reason.

Hopefully helps with further cases of #265.