### PR TITLE
Add version info to main menu

### DIFF
--- a/src/window/main_menu.c
+++ b/src/window/main_menu.c
@@ -1,5 +1,6 @@
 #include "main_menu.h"
 
+#include "core/string.h"
 #include "editor/editor.h"
 #include "game/game.h"
 #include "game/system.h"
@@ -9,7 +10,10 @@
 #include "graphics/image_button.h"
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
+#include "graphics/text.h"
+#include "graphics/screen.h"
 #include "graphics/window.h"
+#include "platform/version.h"
 #include "sound/music.h"
 #include "window/cck_selection.h"
 #include "window/file_dialog.h"
@@ -34,12 +38,30 @@ static generic_button buttons[] = {
 static image_button movie_button =
     {591, 442, 33, 22, IB_NORMAL, 89, 0, button_intro_movie, button_none, 0, 0, 1};
 
+static void draw_version(void)
+{
+    char version_string[100] = "v";
+    int version_length = string_length(JULIUS_VERSION);
+    int text_y = screen_height() - 30;
+
+    string_copy(JULIUS_VERSION, version_string + 1, 99);
+    string_copy(JULIUS_VERSION_SUFFIX, version_string + 1 + version_length, 99 - version_length);
+
+    int text_width = text_get_width(version_string, FONT_SMALL_PLAIN);
+
+    graphics_draw_rect(10, text_y, text_width + 14, 20, COLOR_BLACK);
+    graphics_fill_rect(11, text_y + 1, text_width + 12, 18, COLOR_WHITE);
+
+    text_draw(version_string, 18, text_y + 6, FONT_SMALL_PLAIN, COLOR_BLACK);
+}
+
 static void draw_background(void)
 {
     graphics_clear_screen();
     graphics_in_dialog();
     image_draw(image_group(GROUP_MAIN_MENU_BACKGROUND), 0, 0);
     graphics_reset_dialog();
+    draw_version();
 }
 
 static void draw_foreground(void)

--- a/src/window/main_menu.c
+++ b/src/window/main_menu.c
@@ -38,7 +38,7 @@ static generic_button buttons[] = {
 static image_button movie_button =
     {591, 442, 33, 22, IB_NORMAL, 89, 0, button_intro_movie, button_none, 0, 0, 1};
 
-static void draw_version(void)
+static void draw_version_string(void)
 {
     char version_string[100] = "v";
     int version_length = string_length(JULIUS_VERSION);
@@ -49,10 +49,13 @@ static void draw_version(void)
 
     int text_width = text_get_width(version_string, FONT_SMALL_PLAIN);
 
-    graphics_draw_rect(10, text_y, text_width + 14, 20, COLOR_BLACK);
-    graphics_fill_rect(11, text_y + 1, text_width + 12, 18, COLOR_WHITE);
-
-    text_draw(version_string, 18, text_y + 6, FONT_SMALL_PLAIN, COLOR_BLACK);
+    if (text_y <= 500 && (screen_width() - 640) / 2 < text_width + 18) {
+        graphics_draw_rect(10, text_y, text_width + 14, 20, COLOR_BLACK);
+        graphics_fill_rect(11, text_y + 1, text_width + 12, 18, COLOR_WHITE);
+        text_draw(version_string, 18, text_y + 6, FONT_SMALL_PLAIN, COLOR_BLACK);
+    } else {
+        text_draw(version_string, 18, text_y + 6, FONT_SMALL_PLAIN, COLOR_WHITE);
+    }
 }
 
 static void draw_background(void)
@@ -61,7 +64,7 @@ static void draw_background(void)
     graphics_in_dialog();
     image_draw(image_group(GROUP_MAIN_MENU_BACKGROUND), 0, 0);
     graphics_reset_dialog();
-    draw_version();
+    draw_version_string();
 }
 
 static void draw_foreground(void)

--- a/src/window/main_menu.c
+++ b/src/window/main_menu.c
@@ -40,12 +40,14 @@ static image_button movie_button =
 
 static void draw_version_string(void)
 {
-    char version_string[100] = "v";
-    int version_length = string_length(JULIUS_VERSION);
+    uint8_t version_string[100] = "v";
+    const uint8_t *julius_version = string_from_ascii(JULIUS_VERSION);
+    const uint8_t *julius_version_suffix = string_from_ascii(JULIUS_VERSION_SUFFIX);
+    int version_length = string_length(julius_version);
     int text_y = screen_height() - 30;
 
-    string_copy(JULIUS_VERSION, version_string + 1, 99);
-    string_copy(JULIUS_VERSION_SUFFIX, version_string + 1 + version_length, 99 - version_length);
+    string_copy(julius_version, version_string + 1, 99);
+    string_copy(julius_version_suffix, version_string + 1 + version_length, 99 - version_length);
 
     int text_width = text_get_width(version_string, FONT_SMALL_PLAIN);
 


### PR DESCRIPTION
Now you can easily see what version you have:

When the resolution is low and the version appears over the main menu image, you'll see this:

![version_inside_image](https://user-images.githubusercontent.com/6518876/73498258-af278b00-43b4-11ea-9fde-2519e3e4b5e9.png)

But normally you'll see this:

![version_outside_image](https://user-images.githubusercontent.com/6518876/73498275-bb134d00-43b4-11ea-84b7-088d64e6dabd.png)