### PR TITLE
Redraw backgrounds on window resize

### DIFF
--- a/src/graphics/window.c
+++ b/src/graphics/window.c
@@ -62,6 +62,19 @@ window_id window_get_id(void)
     return current_window->id;
 }
 
+void window_draw_old_behind(void)
+{
+    decrease_queue_index();
+    window_type *window_behind = &window_queue[queue_index];
+    increase_queue_index();
+    if (window_behind->draw_background) {
+        window_behind->draw_background();
+    }
+    if (window_behind->draw_foreground) {
+        window_behind->draw_foreground();
+    }
+}
+
 void window_show(const window_type *window)
 {
     increase_queue_index();

--- a/src/graphics/window.h
+++ b/src/graphics/window.h
@@ -96,9 +96,9 @@ void window_request_refresh(void);
  */
 int window_is_invalid(void);
 
-void window_draw_old_behind(void);
-
 void window_draw(int force);
+
+void window_draw_underlying_window(void);
 
 int window_is(window_id id);
 

--- a/src/graphics/window.h
+++ b/src/graphics/window.h
@@ -96,6 +96,8 @@ void window_request_refresh(void);
  */
 int window_is_invalid(void);
 
+void window_draw_old_behind(void);
+
 void window_draw(int force);
 
 int window_is(window_id id);

--- a/src/widget/minimap.c
+++ b/src/widget/minimap.c
@@ -249,7 +249,7 @@ static void draw_uncached(int x_offset, int y_offset, int width_tiles, int heigh
 
 void draw_using_cache(int x_offset, int y_offset, int width_tiles, int height_tiles, int is_scrolling)
 {
-    if (width_tiles * 2 != data.width || height_tiles != data.height) {
+    if (width_tiles * 2 != data.width || height_tiles != data.height || x_offset != data.x_offset) {
         draw_uncached(x_offset, y_offset, width_tiles, height_tiles);
         return;
     }

--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -428,24 +428,28 @@ static void menu_file_exit_game(int param)
 static void menu_options_display(int param)
 {
     clear_state();
+    window_city_show();
     window_display_options_show(window_city_show);
 }
 
 static void menu_options_sound(int param)
 {
     clear_state();
+    window_city_show();
     window_sound_options_show(window_city_show);
 }
 
 static void menu_options_speed(int param)
 {
     clear_state();
+    window_city_show();
     window_speed_options_show(window_city_show);
 }
 
 static void menu_options_difficulty(int param)
 {
     clear_state();
+    window_city_show();
     window_difficulty_options_show(window_city_show);
 }
 

--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -164,12 +164,17 @@ static void init_from_settings(void)
     set_text_for_warnings();
 }
 
+static void draw_background(void)
+{
+    window_city_draw_panels();
+    window_city_draw();
+}
+
 static void draw_foreground(void)
 {
     if (!data.open_sub_menu) {
         return;
     }
-    window_city_draw();
     menu_draw(&menu[data.open_sub_menu -1], data.focus_sub_menu_id);
 }
 
@@ -182,7 +187,7 @@ static void top_menu_window_show(void)
 {
     window_type window = {
         WINDOW_TOP_MENU,
-        window_city_draw_panels,
+        draw_background,
         draw_foreground,
         handle_mouse,
         0
@@ -284,6 +289,7 @@ static int handle_mouse_submenu(const mouse *m)
     }
     int menu_id = menu_bar_handle_mouse(m, menu, 4, &data.focus_menu_id);
     if (menu_id && menu_id != data.open_sub_menu) {
+        window_city_draw();
         data.open_sub_menu = menu_id;
     }
     if (!menu_handle_mouse(m, &menu[data.open_sub_menu - 1], &data.focus_sub_menu_id)) {
@@ -428,28 +434,24 @@ static void menu_file_exit_game(int param)
 static void menu_options_display(int param)
 {
     clear_state();
-    window_city_show();
     window_display_options_show(window_city_show);
 }
 
 static void menu_options_sound(int param)
 {
     clear_state();
-    window_city_show();
     window_sound_options_show(window_city_show);
 }
 
 static void menu_options_speed(int param)
 {
     clear_state();
-    window_city_show();
     window_speed_options_show(window_city_show);
 }
 
 static void menu_options_difficulty(int param)
 {
     clear_state();
-    window_city_show();
     window_difficulty_options_show(window_city_show);
 }
 

--- a/src/widget/top_menu_editor.c
+++ b/src/widget/top_menu_editor.c
@@ -216,18 +216,21 @@ static void menu_file_exit_editor(int param)
 static void menu_options_display(int param)
 {
     clear_state();
+    window_editor_map_show();
     window_display_options_show(window_editor_map_show);
 }
 
 static void menu_options_sound(int param)
 {
     clear_state();
+    window_editor_map_show();
     window_sound_options_show(window_editor_map_show);
 }
 
 static void menu_options_speed(int param)
 {
     clear_state();
+    window_editor_map_show();
     window_speed_options_show(window_editor_map_show);
 }
 

--- a/src/window/advisor/labor.c
+++ b/src/window/advisor/labor.c
@@ -138,9 +138,3 @@ const advisor_window_type *window_advisor_labor(void)
     };
     return &window;
 }
-
-void window_advisor_labor_draw_dialog_background(void)
-{
-    draw_background();
-    draw_foreground();
-}

--- a/src/window/advisor/labor.h
+++ b/src/window/advisor/labor.h
@@ -5,6 +5,4 @@
 
 const advisor_window_type *window_advisor_labor(void);
 
-void window_advisor_labor_draw_dialog_background(void);
-
 #endif // WINDOW_ADVISOR_LABOR_H

--- a/src/window/city.c
+++ b/src/window/city.c
@@ -66,7 +66,9 @@ static void draw_foreground(void)
     widget_top_menu_draw(0);
     window_city_draw();
     widget_sidebar_draw_foreground();
-    draw_paused_and_time_left();
+    if (window_is(WINDOW_CITY) || window_is(WINDOW_CITY_MILITARY)) {
+        draw_paused_and_time_left();
+    }
     widget_city_draw_construction_cost();
     if (window_is(WINDOW_CITY)) {
         city_message_process_queue();

--- a/src/window/difficulty_options.c
+++ b/src/window/difficulty_options.c
@@ -63,7 +63,7 @@ void window_difficulty_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_DIFFICULTY_OPTIONS,
-        0,
+        window_draw_old_behind,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/difficulty_options.c
+++ b/src/window/difficulty_options.c
@@ -63,7 +63,7 @@ void window_difficulty_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_DIFFICULTY_OPTIONS,
-        window_draw_old_behind,
+        window_draw_underlying_window,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/display_options.c
+++ b/src/window/display_options.c
@@ -89,7 +89,7 @@ void window_display_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_DISPLAY_OPTIONS,
-        0,
+        window_draw_old_behind,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/display_options.c
+++ b/src/window/display_options.c
@@ -89,7 +89,7 @@ void window_display_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_DISPLAY_OPTIONS,
-        window_draw_old_behind,
+        window_draw_underlying_window,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -309,7 +309,7 @@ void window_file_dialog_show(file_type type, file_dialog_type dialog_type)
 {
     window_type window = {
         WINDOW_FILE_DIALOG,
-        window_draw_old_behind,
+        window_draw_underlying_window,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -309,7 +309,7 @@ void window_file_dialog_show(file_type type, file_dialog_type dialog_type)
 {
     window_type window = {
         WINDOW_FILE_DIALOG,
-        0,
+        window_draw_old_behind,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/labor_priority.c
+++ b/src/window/labor_priority.c
@@ -6,7 +6,6 @@
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 #include "graphics/window.h"
-#include "window/advisor/labor.h"
 
 #define MIN_DIALOG_WIDTH 320
 
@@ -52,9 +51,9 @@ static int get_dialog_width(void)
 
 static void draw_background(void)
 {
-    graphics_in_dialog();
+    window_draw_old_behind();
 
-    window_advisor_labor_draw_dialog_background();
+    graphics_in_dialog();
 
     int dialog_width = get_dialog_width();
     int dialog_x = 160 - (dialog_width - MIN_DIALOG_WIDTH) / 2;
@@ -98,7 +97,7 @@ static void draw_foreground(void)
 static void handle_mouse(const mouse *m)
 {
     if (m->right.went_up) {
-        window_advisors_show();
+        window_go_back();
     } else {
         generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, priority_buttons, 1 + data.max_items, &data.focus_button_id);
     }
@@ -107,7 +106,7 @@ static void handle_mouse(const mouse *m)
 static void button_set_priority(int new_priority, int param2)
 {
     city_labor_set_priority(data.category, new_priority);
-    window_advisors_show();
+    window_go_back();
 }
 
 static void get_tooltip(tooltip_context *c)

--- a/src/window/labor_priority.c
+++ b/src/window/labor_priority.c
@@ -51,7 +51,7 @@ static int get_dialog_width(void)
 
 static void draw_background(void)
 {
-    window_draw_old_behind();
+    window_draw_underlying_window();
 
     graphics_in_dialog();
 

--- a/src/window/main_menu.c
+++ b/src/window/main_menu.c
@@ -65,7 +65,9 @@ static void draw_background(void)
     graphics_in_dialog();
     image_draw(image_group(GROUP_MAIN_MENU_BACKGROUND), 0, 0);
     graphics_reset_dialog();
-    draw_version_string();
+    if (window_get_id() == WINDOW_MAIN_MENU) {
+        draw_version_string();
+    }
 }
 
 static void draw_foreground(void)

--- a/src/window/main_menu.c
+++ b/src/window/main_menu.c
@@ -65,7 +65,7 @@ static void draw_background(void)
     graphics_in_dialog();
     image_draw(image_group(GROUP_MAIN_MENU_BACKGROUND), 0, 0);
     graphics_reset_dialog();
-    if (window_get_id() == WINDOW_MAIN_MENU) {
+    if (window_is(WINDOW_MAIN_MENU)) {
         draw_version_string();
     }
 }

--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -391,6 +391,8 @@ static void draw_background(void)
 {
     if (data.background_callback) {
         data.background_callback();
+    } else {
+        window_draw_old_behind();
     }
     graphics_in_dialog();
     if (data.show_video) {

--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -392,7 +392,7 @@ static void draw_background(void)
     if (data.background_callback) {
         data.background_callback();
     } else {
-        window_draw_old_behind();
+        window_draw_underlying_window();
     }
     graphics_in_dialog();
     if (data.show_video) {

--- a/src/window/mission_briefing.c
+++ b/src/window/mission_briefing.c
@@ -56,7 +56,7 @@ static void draw_background(void)
         }
     }
 
-    window_draw_old_behind();
+    window_draw_underlying_window();
     
     graphics_in_dialog();
     int text_id = 200 + scenario_campaign_mission();

--- a/src/window/mission_briefing.c
+++ b/src/window/mission_briefing.c
@@ -55,6 +55,8 @@ static void draw_background(void)
             return;
         }
     }
+
+    window_draw_old_behind();
     
     graphics_in_dialog();
     int text_id = 200 + scenario_campaign_mission();

--- a/src/window/popup_dialog.c
+++ b/src/window/popup_dialog.c
@@ -39,6 +39,7 @@ static int init(popup_dialog_type type, void (*close_func)(int accepted), int ha
 
 static void draw_background(void)
 {
+    window_draw_old_behind();
     graphics_in_dialog();
     outer_panel_draw(80, 80, 30, 10);
     lang_text_draw_centered(GROUP, data.type, 80, 100, 480, FONT_LARGE_BLACK);

--- a/src/window/popup_dialog.c
+++ b/src/window/popup_dialog.c
@@ -39,7 +39,7 @@ static int init(popup_dialog_type type, void (*close_func)(int accepted), int ha
 
 static void draw_background(void)
 {
-    window_draw_old_behind();
+    window_draw_underlying_window();
     graphics_in_dialog();
     outer_panel_draw(80, 80, 30, 10);
     lang_text_draw_centered(GROUP, data.type, 80, 100, 480, FONT_LARGE_BLACK);

--- a/src/window/sound_options.c
+++ b/src/window/sound_options.c
@@ -201,7 +201,7 @@ void window_sound_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_SOUND_OPTIONS,
-        window_draw_old_behind,
+        window_draw_underlying_window,
         draw_foreground,
         handle_mouse,
     };

--- a/src/window/sound_options.c
+++ b/src/window/sound_options.c
@@ -201,7 +201,7 @@ void window_sound_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_SOUND_OPTIONS,
-        0,
+        window_draw_old_behind,
         draw_foreground,
         handle_mouse,
     };

--- a/src/window/speed_options.c
+++ b/src/window/speed_options.c
@@ -113,7 +113,7 @@ void window_speed_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_SPEED_OPTIONS,
-        0,
+        window_draw_old_behind,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/speed_options.c
+++ b/src/window/speed_options.c
@@ -113,7 +113,7 @@ void window_speed_options_show(void (*close_callback)(void))
 {
     window_type window = {
         WINDOW_SPEED_OPTIONS,
-        window_draw_old_behind,
+        window_draw_underlying_window,
         draw_foreground,
         handle_mouse
     };

--- a/src/window/trade_prices.c
+++ b/src/window/trade_prices.c
@@ -12,6 +12,8 @@
 
 static void draw_background(void)
 {
+    window_draw_old_behind();
+
     graphics_in_dialog();
 
     graphics_shade_rect(33, 53, 574, 334, 0);

--- a/src/window/trade_prices.c
+++ b/src/window/trade_prices.c
@@ -12,7 +12,7 @@
 
 static void draw_background(void)
 {
-    window_draw_old_behind();
+    window_draw_underlying_window();
 
     graphics_in_dialog();
 


### PR DESCRIPTION
Redraws the backgrounds (for example, on file dialog window or on most sub-windows of the advisors) when the Julius window is resized, instead of just showing a black background.

Fix #66.