### PR TITLE
Add a "go to problem" button on disaster and invasion messages with videos

### DIFF
--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -136,6 +136,11 @@ static int resource_image(int resource)
     return image_id;
 }
 
+static int is_problem_message(const lang_message *msg)
+{
+    return msg->type == TYPE_MESSAGE && (msg->message_type == MESSAGE_TYPE_DISASTER || msg->message_type == MESSAGE_TYPE_INVASION);
+}
+
 static void draw_city_message_text(const lang_message *msg)
 {
     if (msg->message_type != MESSAGE_TYPE_TUTORIAL) {
@@ -452,7 +457,7 @@ static void draw_foreground_video(void)
     image_buttons_draw(data.x + 16, data.y + 408, get_advisor_button(), 1);
     image_buttons_draw(data.x + 372, data.y + 410, &image_button_close, 1);
     const lang_message *msg = lang_get_message(data.text_id);
-    if (msg->type == TYPE_MESSAGE && (msg->message_type == MESSAGE_TYPE_DISASTER || msg->message_type == MESSAGE_TYPE_INVASION)) {
+    if (is_problem_message(msg)) {
         image_buttons_draw(data.x + 48, data.y + 407, &image_button_go_to_problem, 1);
     }
 }
@@ -480,7 +485,7 @@ static void handle_mouse(const mouse *m)
         if (image_buttons_handle_mouse(m_dialog, data.x + 372, data.y + 410, &image_button_close, 1, 0)) {
             return;
         }
-        if (msg->type == TYPE_MESSAGE && (msg->message_type == MESSAGE_TYPE_DISASTER || msg->message_type == MESSAGE_TYPE_INVASION)) {
+        if (is_problem_message(msg)) {
             image_buttons_handle_mouse(m_dialog, data.x + 48, data.y + 407, &image_button_go_to_problem, 1, &data.focus_button_id);
         }
         return;

--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -82,6 +82,7 @@ static struct {
     int y_text;
     int text_height_blocks;
     int text_width_blocks;
+    int focus_button_id;
 } data;
 
 static struct {
@@ -469,6 +470,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
+    data.focus_button_id = 0;
     const mouse *m_dialog = mouse_in_dialog(m);
     const lang_message *msg = lang_get_message(data.text_id);
     if (data.show_video) {
@@ -479,7 +481,7 @@ static void handle_mouse(const mouse *m)
             return;
         }
         if (msg->type == TYPE_MESSAGE && (msg->message_type == MESSAGE_TYPE_DISASTER || msg->message_type == MESSAGE_TYPE_INVASION)) {
-            image_buttons_handle_mouse(m_dialog, data.x + 48, data.y + 407, &image_button_go_to_problem, 1, 0);
+            image_buttons_handle_mouse(m_dialog, data.x + 48, data.y + 407, &image_button_go_to_problem, 1, &data.focus_button_id);
         }
         return;
     }
@@ -577,6 +579,15 @@ static void button_go_to_problem(int param1, int param2)
     window_city_show();
 }
 
+static void get_tooltip(tooltip_context *c)
+{
+    if (data.focus_button_id) {
+        c->type = TOOLTIP_BUTTON;
+        c->text_group = 12;
+        c->text_id = 1;
+    }
+}
+
 void window_message_dialog_show(int text_id, void (*background_callback)(void))
 {
     window_type window = {
@@ -584,7 +595,7 @@ void window_message_dialog_show(int text_id, void (*background_callback)(void))
         draw_background,
         draw_foreground,
         handle_mouse,
-        0
+        get_tooltip
     };
     init(text_id, background_callback);
     window_show(&window);

--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -350,7 +350,7 @@ static void draw_background_video(void)
     width += lang_text_draw_year(player_message.year, data.x + 18 + width, y_base + 4, FONT_NORMAL_WHITE);
     
     if (msg->type == TYPE_MESSAGE && msg->message_type == MESSAGE_TYPE_DISASTER &&
-        data.text_id == 251) {
+        data.text_id == MESSAGE_DIALOG_THEFT) {
         lang_text_draw_amount(8, 0, player_message.param1, data.x + 90 + width, y_base + 4, FONT_NORMAL_WHITE);
     } else {
         width += lang_text_draw(63, 5, data.x + 90 + width, y_base + 4, FONT_NORMAL_WHITE);
@@ -450,6 +450,10 @@ static void draw_foreground_video(void)
     video_draw(data.x + 8, data.y + 8);
     image_buttons_draw(data.x + 16, data.y + 408, get_advisor_button(), 1);
     image_buttons_draw(data.x + 372, data.y + 410, &image_button_close, 1);
+    const lang_message *msg = lang_get_message(data.text_id);
+    if (msg->type == TYPE_MESSAGE && (msg->message_type == MESSAGE_TYPE_DISASTER || msg->message_type == MESSAGE_TYPE_INVASION)) {
+        image_buttons_draw(data.x + 48, data.y + 407, &image_button_go_to_problem, 1);
+    }
 }
 
 static void draw_foreground(void)
@@ -466,15 +470,20 @@ static void draw_foreground(void)
 static void handle_mouse(const mouse *m)
 {
     const mouse *m_dialog = mouse_in_dialog(m);
+    const lang_message *msg = lang_get_message(data.text_id);
     if (data.show_video) {
-        if (!image_buttons_handle_mouse(m_dialog, data.x + 16, data.y + 408, get_advisor_button(), 1, 0)) {
-            image_buttons_handle_mouse(m_dialog, data.x + 372, data.y + 410, &image_button_close, 1, 0);
+        if (image_buttons_handle_mouse(m_dialog, data.x + 16, data.y + 408, get_advisor_button(), 1, 0)) {
+            return;
+        }
+        if (image_buttons_handle_mouse(m_dialog, data.x + 372, data.y + 410, &image_button_close, 1, 0)) {
+            return;
+        }
+        if (msg->type == TYPE_MESSAGE && (msg->message_type == MESSAGE_TYPE_DISASTER || msg->message_type == MESSAGE_TYPE_INVASION)) {
+            image_buttons_handle_mouse(m_dialog, data.x + 48, data.y + 407, &image_button_go_to_problem, 1, 0);
         }
         return;
     }
     // no video
-    const lang_message *msg = lang_get_message(data.text_id);
-
     if (msg->type == TYPE_MANUAL && image_buttons_handle_mouse(
                 m_dialog, data.x + 16, data.y + 16 * msg->height_blocks - 36, &image_button_back, 1, 0)) {
         return;


### PR DESCRIPTION
Result:

![go_to_problem](https://user-images.githubusercontent.com/6518876/73791717-ca224280-479a-11ea-95f9-80dd139d4061.png)

Also displays a tooltip with the text `Go to problem area` when hovering the button.