### PR TITLE
Make construction cost color slightly lighter on central and northern maps

### DIFF
--- a/src/graphics/color.h
+++ b/src/graphics/color.h
@@ -9,6 +9,7 @@ typedef uint32_t color_t;
 #define COLOR_BLUE 0x0055ff
 #define COLOR_RED 0xff0000
 #define COLOR_ORANGE 0xff5a08
+#define COLOR_ORANGE_LIGHT 0xffa500
 #define COLOR_YELLOW 0xe7e75a
 #define COLOR_WHITE 0xffffff
 #define COLOR_TRANSPARENT 0xf700ff

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -74,7 +74,7 @@ void widget_city_draw_construction_cost(void)
     color_t color;
     if (cost <= city_finance_treasury()) {
         // Color blind friendly
-        color = (scenario_property_climate() == CLIMATE_DESERT) ? COLOR_ORANGE : COLOR_ORANGE_LIGHT;
+        color = scenario_property_climate() == CLIMATE_DESERT ? COLOR_ORANGE : COLOR_ORANGE_LIGHT;
     } else {
         color = COLOR_RED;
     }

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -14,6 +14,7 @@
 #include "input/touch.h"
 #include "map/building.h"
 #include "map/grid.h"
+#include "scenario/property.h"
 #include "sound/city.h"
 #include "sound/speech.h"
 #include "sound/effect.h"
@@ -72,7 +73,8 @@ void widget_city_draw_construction_cost(void)
     set_city_clip_rectangle();
     color_t color;
     if (cost <= city_finance_treasury()) {
-        color = COLOR_ORANGE;
+        // Color blind friendly
+        color = (scenario_property_climate() == CLIMATE_DESERT) ? COLOR_ORANGE : COLOR_ORANGE_LIGHT;
     } else {
         color = COLOR_RED;
     }


### PR DESCRIPTION
Since I'm color blind, I had trouble reading the construction cost on the northern/central maps as for me it looked almost the same as the terrain color.

This improves things without changing the overall color of the construction cost. It's slightly lighter on northern and central maps, and the same color on desert maps.

However, short of adding a white box like in the tooltips, some color blind people with different types of color blindness will still have trouble reading the cost. Hopefully that's rare enough that it won't matter.