### PR TITLE
Save full-city screenshots as a bmp by pressing CTRL+F12

### DIFF
--- a/src/city/view.c
+++ b/src/city/view.c
@@ -88,10 +88,10 @@ static void calculate_lookup(void)
             y_view_step = 1;
             break;
         case DIR_2_RIGHT:
-            x_view_start = 1;
+            x_view_start = 3;
             x_view_skip = 1;
             x_view_step = 1;
-            y_view_start = VIEW_X_MAX - 1;
+            y_view_start = VIEW_X_MAX - 3;
             y_view_skip = 1;
             y_view_step = -1;
             break;
@@ -104,10 +104,10 @@ static void calculate_lookup(void)
             y_view_step = -1;
             break;
         case DIR_6_LEFT:
-            x_view_start = VIEW_Y_MAX - 2;
+            x_view_start = VIEW_Y_MAX;
             x_view_skip = -1;
             x_view_step = -1;
-            y_view_start = VIEW_X_MAX - 1;
+            y_view_start = VIEW_X_MAX - 3;
             y_view_skip = -1;
             y_view_step = 1;
             break;
@@ -324,10 +324,6 @@ void city_view_rotate_left(void)
         city_view_grid_offset_to_xy_view(center_grid_offset, &x, &y);
         data.camera.tile.x = x - data.viewport.width_tiles / 2;
         data.camera.tile.y = y - data.viewport.height_tiles / 2;
-        if (data.orientation == DIR_0_TOP ||
-            data.orientation == DIR_4_BOTTOM) {
-            data.camera.tile.x++;
-        }
     }
     check_camera_boundaries();
 }
@@ -346,10 +342,6 @@ void city_view_rotate_right(void)
         city_view_grid_offset_to_xy_view(center_grid_offset, &x, &y);
         data.camera.tile.x = x - data.viewport.width_tiles / 2;
         data.camera.tile.y = y - data.viewport.height_tiles / 2;
-        if (data.orientation == DIR_0_TOP ||
-            data.orientation == DIR_4_BOTTOM) {
-            data.camera.tile.y += 2;
-        }
     }
     check_camera_boundaries();
 }

--- a/src/graphics/screenshot.c
+++ b/src/graphics/screenshot.c
@@ -1,10 +1,14 @@
 #include "screenshot.h"
 
+#include "city/view.h"
 #include "core/buffer.h"
 #include "core/file.h"
 #include "core/log.h"
 #include "graphics/screen.h"
 #include "graphics/graphics.h"
+#include "map/grid.h"
+#include "graphics/window.h"
+#include "widget/city_without_overlay.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,8 +16,53 @@
 #include <time.h>
 
 #define HEADER_SIZE 26
+#define TILE_X_SIZE 60
+#define TILE_Y_SIZE 30
+#define IMAGE_HEIGHT_CHUNK (2 * TILE_Y_SIZE)
+#define BMP_BITS_PER_PIXEL 24
+#define BMP_BYTES_PER_PIXEL (BMP_BITS_PER_PIXEL / 8)
 
 static const char filename_format[] = "city %Y-%m-%d %H.%M.%S.bmp";
+
+static void full_city_screenshot(void);
+
+static struct {
+    int width;
+    int height;
+    int scanline_size;
+    uint8_t *pixels;
+} bmp_chunk;
+
+static void free_bmp_chunk(void)
+{
+    bmp_chunk.width = 0;
+    bmp_chunk.height = 0;
+    bmp_chunk.scanline_size = 0;
+    free(bmp_chunk.pixels);
+    bmp_chunk.pixels = 0;
+}
+
+static int create_bmp_chunk(int width, int height)
+{
+    free(bmp_chunk.pixels);
+    if (!width || !height) {
+        return 0;
+    }
+    int scanline_padding = 4 - (width * BMP_BYTES_PER_PIXEL) % 4;
+    if (scanline_padding == 4) {
+        scanline_padding = 0;
+    }
+    bmp_chunk.width = width;
+    bmp_chunk.height = height;
+    bmp_chunk.scanline_size = width * BMP_BYTES_PER_PIXEL + scanline_padding;
+    bmp_chunk.pixels = (uint8_t *) malloc(bmp_chunk.scanline_size * height);
+    if (!bmp_chunk.pixels) {
+        free_bmp_chunk();
+        return 0;
+    }
+    memset(bmp_chunk.pixels, 0, bmp_chunk.scanline_size * height);
+    return 1;
+}
 
 static const char *generate_filename(void)
 {
@@ -26,18 +75,18 @@ static const char *generate_filename(void)
     return filename;
 }
 
-static void write_bmp_header(buffer *buf, int width, int height, int scanline_size)
+static void write_bmp_header(buffer *buf, int full_height)
 {
     buffer_write_i8(buf, 'B');
     buffer_write_i8(buf, 'M');
-    buffer_write_i32(buf, HEADER_SIZE + scanline_size * height); // file size
+    buffer_write_i32(buf, HEADER_SIZE + bmp_chunk.scanline_size * full_height); // file size
     buffer_write_i32(buf, 0); // reserved
     buffer_write_i32(buf, HEADER_SIZE); // data offset
     buffer_write_i32(buf, 12); // dib size
-    buffer_write_i16(buf, (int16_t) width);
-    buffer_write_i16(buf, (int16_t) height);
+    buffer_write_i16(buf, (int16_t) bmp_chunk.width);
+    buffer_write_i16(buf, (int16_t) full_height);
     buffer_write_i16(buf, 1); // planes
-    buffer_write_i16(buf, 24); // bpp
+    buffer_write_i16(buf, BMP_BITS_PER_PIXEL);
 }
 
 static void pixel(color_t input, uint8_t *r, uint8_t *g, uint8_t *b)
@@ -50,8 +99,12 @@ static void pixel(color_t input, uint8_t *r, uint8_t *g, uint8_t *b)
     *b = (uint8_t) bb;
 }
 
-void graphics_save_screenshot(void)
+void graphics_save_screenshot(int full_city)
 {
+    if (full_city) {
+        full_city_screenshot();
+        return;
+    }
     uint8_t header[HEADER_SIZE];
     buffer buf;
     buffer_init(&buf, header, HEADER_SIZE);
@@ -60,36 +113,93 @@ void graphics_save_screenshot(void)
     int height = screen_height();
     const color_t *canvas = graphics_canvas();
 
-    int scanline_padding = 4 - (width * 3) % 4;
-    if (scanline_padding == 4) {
-        scanline_padding = 0;
-    }
-    int scanline_size = width * 3 + scanline_padding;
-    uint8_t *pixels = (uint8_t*) malloc(scanline_size);
-    if (!pixels) {
+    if (!create_bmp_chunk(width, 1)) {
+        log_error("Unable to create memory for screenshot", 0, 0);
         return;
     }
-    memset(pixels, 0, scanline_size);
 
     const char *filename = generate_filename();
     FILE *fp = file_open(filename, "wb");
     if (!fp) {
         log_error("Unable to write screenshot to:", filename, 0);
-        free(pixels);
+        free_bmp_chunk();
         return;
     }
 
-    write_bmp_header(&buf, width, height, scanline_size);
+    write_bmp_header(&buf, height);
     fwrite(header, 1, HEADER_SIZE, fp);
     for (int y = height - 1; y >= 0; y--) {
         for (int x = 0; x < width; x++) {
             pixel(canvas[y * width + x],
-                &pixels[3*x+2], &pixels[3*x+1], &pixels[3*x]);
+                &bmp_chunk.pixels[3*x+2], &bmp_chunk.pixels[3*x+1], &bmp_chunk.pixels[3*x]);
         }
-        fwrite(pixels, 1, scanline_size, fp);
+        fwrite(bmp_chunk.pixels, sizeof(uint8_t), bmp_chunk.scanline_size, fp);
     }
     file_close(fp);
-    free(pixels);
+    free_bmp_chunk();
 
     log_info("Saved screenshot:", filename, 0);
+}
+
+static void full_city_screenshot(void)
+{
+    if (!window_is(WINDOW_CITY) && !window_is(WINDOW_CITY_MILITARY)) {
+        return;
+    }
+    pixel_offset original_camera_pixels;
+    city_view_get_camera_in_pixels(&original_camera_pixels.x, &original_camera_pixels.y);
+    int width = screen_width();
+    int height = screen_height();
+
+    int city_width_pixels = map_grid_width() * TILE_X_SIZE;
+    int city_height_pixels = map_grid_height() * TILE_Y_SIZE;
+
+    if (!create_bmp_chunk(city_width_pixels, IMAGE_HEIGHT_CHUNK)) {
+        log_error("Unable to assign memory for full city screenshot creation", 0, 0);
+        return;
+    }
+
+    const char *filename = generate_filename();
+    FILE *fp = file_open(filename, "wb");
+    if (!fp) {
+        log_error("Unable to write screenshot to:", filename, 0);
+        free_bmp_chunk();
+        return;
+    }
+
+    uint8_t header[HEADER_SIZE];
+    buffer buf;
+    buffer_init(&buf, header, HEADER_SIZE);
+    write_bmp_header(&buf, city_height_pixels);
+    fwrite(header, 1, HEADER_SIZE, fp);
+
+    int new_width = city_width_pixels + (city_view_is_sidebar_collapsed() ? 40 : 160);
+    screen_set_resolution(new_width, 24 + IMAGE_HEIGHT_CHUNK);
+    graphics_set_clip_rectangle(0, 24, city_width_pixels, IMAGE_HEIGHT_CHUNK);
+
+    int base_width = (GRID_SIZE * TILE_X_SIZE - city_width_pixels) / 2 + TILE_X_SIZE;
+    int max_height = (GRID_SIZE * TILE_Y_SIZE + city_height_pixels) / 2;
+    int min_height = max_height - city_height_pixels;
+    map_tile dummy_tile = { 0, 0, 0 };
+    const color_t *canvas = graphics_canvas();
+
+    for (int current_height = max_height - IMAGE_HEIGHT_CHUNK; current_height >= min_height; current_height -= IMAGE_HEIGHT_CHUNK) {
+        city_view_set_camera_from_pixel_position(base_width, current_height);
+        city_without_overlay_draw(0, 0, &dummy_tile);
+        for (int y = IMAGE_HEIGHT_CHUNK - 1; y >= 0; y--) {
+            for (int x = 0; x < city_width_pixels; x++) {
+                pixel(canvas[(y + 24) * new_width + x],
+                    &bmp_chunk.pixels[3 * x + 2], &bmp_chunk.pixels[3 * x + 1], &bmp_chunk.pixels[3 * x]);
+            }
+            fwrite(bmp_chunk.pixels, sizeof(uint8_t), bmp_chunk.scanline_size, fp);
+        }
+    }
+    graphics_reset_clip_rectangle();
+    screen_set_resolution(width, height);
+    city_view_set_camera_from_pixel_position(original_camera_pixels.x, original_camera_pixels.y);
+
+    file_close(fp);
+    free_bmp_chunk();
+
+    log_info("Saved full city screenshot:", filename, 0);
 }

--- a/src/graphics/screenshot.h
+++ b/src/graphics/screenshot.h
@@ -1,6 +1,6 @@
 #ifndef GRAPHICS_SCREENSHOT_H
 #define GRAPHICS_SCREENSHOT_H
 
-void graphics_save_screenshot(void);
+void graphics_save_screenshot(int full_city);
 
 #endif // GRAPHICS_SCREENSHOT_H

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -386,20 +386,20 @@ static void take_screenshot(int full_city)
     graphics_save_screenshot(full_city);
 }
 
-void hotkey_func(int f_number, int with_modifier)
+void hotkey_func(int f_number, int with_ctrl)
 {
     switch (f_number) {
         case 1:
         case 2:
         case 3:
         case 4:
-            handle_bookmark(f_number - 1, with_modifier);
+            handle_bookmark(f_number - 1, with_ctrl);
             break;
         case 5: system_center(); break;
         case 6: system_set_fullscreen(!setting_fullscreen()); break;
         case 7: system_resize(640, 480); break;
         case 8: system_resize(800, 600); break;
         case 9: system_resize(1024, 768); break;
-        case 12: take_screenshot(with_modifier); break;
+        case 12: take_screenshot(with_ctrl); break;
     }
 }

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -386,14 +386,14 @@ static void take_screenshot(int full_city)
     graphics_save_screenshot(full_city);
 }
 
-void hotkey_func(int f_number, int with_ctrl)
+void hotkey_func(int f_number, int with_any_modifier, int with_ctrl)
 {
     switch (f_number) {
         case 1:
         case 2:
         case 3:
         case 4:
-            handle_bookmark(f_number - 1, with_ctrl);
+            handle_bookmark(f_number - 1, with_any_modifier);
             break;
         case 5: system_center(); break;
         case 6: system_set_fullscreen(!setting_fullscreen()); break;

--- a/src/input/hotkey.c
+++ b/src/input/hotkey.c
@@ -381,9 +381,9 @@ static void handle_bookmark(int number, int with_modifier)
     }
 }
 
-static void take_screenshot(void)
+static void take_screenshot(int full_city)
 {
-    graphics_save_screenshot();
+    graphics_save_screenshot(full_city);
 }
 
 void hotkey_func(int f_number, int with_modifier)
@@ -400,6 +400,6 @@ void hotkey_func(int f_number, int with_modifier)
         case 7: system_resize(640, 480); break;
         case 8: system_resize(800, 600); break;
         case 9: system_resize(1024, 768); break;
-        case 12: take_screenshot(); break;
+        case 12: take_screenshot(with_modifier); break;
     }
 }

--- a/src/input/hotkey.h
+++ b/src/input/hotkey.h
@@ -18,6 +18,6 @@ void hotkey_page_up(void);
 void hotkey_page_down(void);
 void hotkey_enter(void);
 
-void hotkey_func(int f_number, int with_ctrl);
+void hotkey_func(int f_number, int with_any_modifier, int with_ctrl);
 
 #endif // INPUT_HOTKEY_H

--- a/src/input/hotkey.h
+++ b/src/input/hotkey.h
@@ -18,6 +18,6 @@ void hotkey_page_up(void);
 void hotkey_page_down(void);
 void hotkey_enter(void);
 
-void hotkey_func(int f_number, int with_modifier);
+void hotkey_func(int f_number, int with_ctrl);
 
 #endif // INPUT_HOTKEY_H

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -33,7 +33,8 @@ static int is_repeatable_key(SDL_Keycode code)
 
 static void send_fn(SDL_KeyboardEvent *event, int f_number)
 {
-    hotkey_func(f_number, is_ctrl_down(event));
+    int with_any_modifier = (event->keysym.mod & (KMOD_CTRL | KMOD_SHIFT | KMOD_GUI)) != 0;
+    hotkey_func(f_number, with_any_modifier, is_ctrl_down(event));
 }
 
 void platform_handle_key_down(SDL_KeyboardEvent *event)

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -3,12 +3,6 @@
 #include "input/hotkey.h"
 #include "input/keyboard.h"
 
-static void send_fn(SDL_KeyboardEvent *event, int f_number)
-{
-    int with_modifier = (event->keysym.mod & (KMOD_CTRL | KMOD_SHIFT | KMOD_GUI)) != 0;
-    hotkey_func(f_number, with_modifier);
-}
-
 static int is_ctrl_down(SDL_KeyboardEvent *event)
 {
     return (event->keysym.mod & KMOD_CTRL) != 0;
@@ -35,6 +29,11 @@ static int is_repeatable_key(SDL_Keycode code)
     return code == SDLK_UP || code == SDLK_DOWN ||
            code == SDLK_LEFT || code == SDLK_RIGHT ||
            code == SDLK_BACKSPACE || code == SDLK_DELETE;
+}
+
+static void send_fn(SDL_KeyboardEvent *event, int f_number)
+{
+    hotkey_func(f_number, is_ctrl_down(event));
 }
 
 void platform_handle_key_down(SDL_KeyboardEvent *event)


### PR DESCRIPTION
Fix #300.

Note: For enourmous maps, the image size will be 135MB. Convert manually to a different image format to reduce file size (palette-based PNG is recommended).