### PR TITLE
Fix wrong times being set for intro video frame positions

### DIFF
--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -480,6 +480,8 @@ static void setup(const julius_args *args)
     // this has to come after platform_screen_create, otherwise it fails on Nintendo Switch
     platform_init_cursors(args->cursor_scale_percentage);
 
+    time_set_millis(SDL_GetTicks());
+
     if (!game_init()) {
         SDL_Log("Exiting: game init failed");
         exit(2);


### PR DESCRIPTION
This was originally reported by @411752230 on #195, but it turns out it's a common problem to all platforms.

When intro videos were active, they were being started before `time_set_millis()` was ever called. This meant that the first frames of the first video could be skipped.

For Android, this meant that on every restart the old time value was used to determine the current video frame, so the entire video was frameskipped.

Adding `time_set_millis()` before `game_init()` fixes the issue.