### PR TITLE
Fix many of the graphics artifacts while building draggable reservoirs

### DIFF
--- a/src/city/view.c
+++ b/src/city/view.c
@@ -272,24 +272,25 @@ int city_view_pixels_to_view_tile(int x_pixels, int y_pixels, view_tile *tile)
             x_view_offset++;
         }
     }
-    data.selected_tile.x_pixels = data.viewport.x + TILE_WIDTH_PIXELS * x_view_offset - data.camera.pixel.x;
-    if (y_view_offset & 1) {
-        data.selected_tile.x_pixels -= HALF_TILE_WIDTH_PIXELS;
-    }
-    data.selected_tile.y_pixels = data.viewport.y + HALF_TILE_HEIGHT_PIXELS * y_view_offset - HALF_TILE_HEIGHT_PIXELS - data.camera.pixel.y; // TODO why -1?
-
     tile->x = data.camera.tile.x + x_view_offset;
     tile->y = data.camera.tile.y + y_view_offset;
     return 1;
 }
 
-int city_view_pixels_to_grid_offset(int x_pixels, int y_pixels)
+void city_view_set_selected_view_tile(const view_tile *tile)
 {
-    view_tile view;
-    if (!city_view_pixels_to_view_tile(x_pixels, y_pixels, &view)) {
-        return 0;
+    int x_view_offset = tile->x - data.camera.tile.x;
+    int y_view_offset = tile->y - data.camera.tile.y;
+    data.selected_tile.x_pixels = data.viewport.x + TILE_WIDTH_PIXELS * x_view_offset - data.camera.pixel.x;
+    if (y_view_offset & 1) {
+        data.selected_tile.x_pixels -= HALF_TILE_WIDTH_PIXELS;
     }
-    int grid_offset = view_to_grid_offset_lookup[view.x][view.y];
+    data.selected_tile.y_pixels = data.viewport.y + HALF_TILE_HEIGHT_PIXELS * y_view_offset - HALF_TILE_HEIGHT_PIXELS - data.camera.pixel.y; // TODO why -1?
+}
+
+int city_view_tile_to_grid_offset(const view_tile *tile)
+{
+    int grid_offset = view_to_grid_offset_lookup[tile->x][tile->y];
     return grid_offset < 0 ? 0 : grid_offset;
 }
 

--- a/src/city/view.h
+++ b/src/city/view.h
@@ -38,7 +38,9 @@ void city_view_get_selected_tile_pixels(int *x_pixels, int *y_pixels);
 
 int city_view_pixels_to_view_tile(int x_pixels, int y_pixels, view_tile *tile);
 
-int city_view_pixels_to_grid_offset(int x_pixels, int y_pixels);
+void city_view_set_selected_view_tile(const view_tile *tile);
+
+int city_view_tile_to_grid_offset(const view_tile *tile);
 
 void city_view_go_to_grid_offset(int grid_offset);
 

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -89,7 +89,10 @@ void widget_city_draw_construction_cost(void)
 
 static void update_city_view_coords(int x, int y, map_tile *tile)
 {
-    tile->grid_offset = city_view_pixels_to_grid_offset(x, y);
+    view_tile view;
+    city_view_pixels_to_view_tile(x, y, &view);
+    tile->grid_offset = city_view_tile_to_grid_offset(&view);
+    city_view_set_selected_view_tile(&view);
     if (tile->grid_offset) {
         tile->x = map_grid_offset_to_x(tile->grid_offset);
         tile->y = map_grid_offset_to_y(tile->grid_offset);

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -90,14 +90,13 @@ void widget_city_draw_construction_cost(void)
 static void update_city_view_coords(int x, int y, map_tile *tile)
 {
     view_tile view;
-    city_view_pixels_to_view_tile(x, y, &view);
-    tile->grid_offset = city_view_tile_to_grid_offset(&view);
-    city_view_set_selected_view_tile(&view);
-    if (tile->grid_offset) {
+    if (city_view_pixels_to_view_tile(x, y, &view)) {
+        tile->grid_offset = city_view_tile_to_grid_offset(&view);
+        city_view_set_selected_view_tile(&view);
         tile->x = map_grid_offset_to_x(tile->grid_offset);
         tile->y = map_grid_offset_to_y(tile->grid_offset);
     } else {
-        tile->x = tile->y = 0;
+        tile->grid_offset = tile->x = tile->y = 0;
     }
 }
 

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -316,7 +316,9 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
                 draw_flat_tile(x_start + X_VIEW_OFFSETS[i], y_start + Y_VIEW_OFFSETS[i], COLOR_MASK_RED);
             }
         } else {
-            offset = city_view_pixels_to_grid_offset(x_start, y_start);
+            view_tile view;
+            city_view_pixels_to_view_tile(x_start, y_start, &view);
+            offset = city_view_tile_to_grid_offset(&view);
             int map_x_start = map_grid_offset_to_x(offset) - 1;
             int map_y_start = map_grid_offset_to_y(offset) - 1;
             if (!has_water) {
@@ -327,7 +329,6 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
             } else {
                 draw_single_reservoir(x_start, y_start, has_water);
             }
-            city_view_pixels_to_grid_offset(x, y);
         }
     }
     // mouse pointer = center tile of reservoir instead of north, correct here:

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -324,9 +324,21 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
             if (!has_water) {
                 has_water = map_terrain_exists_tile_in_area_with_type(map_x_start - 1, map_y_start - 1, 5, TERRAIN_WATER);
             }
-            if (map_x_start > map_x || map_y_start > map_y) {
-                draw_later = 1;
-            } else {
+            switch (city_view_orientation()) {
+                case DIR_0_TOP:
+                    draw_later = (map_x_start > map_x || map_y_start > map_y);
+                    break;
+                case DIR_2_RIGHT:
+                    draw_later = (map_x_start < map_x || map_y_start > map_y);
+                    break;
+                case DIR_4_BOTTOM:
+                    draw_later = (map_x_start < map_x || map_y_start < map_y);
+                    break;
+                case DIR_6_LEFT:
+                    draw_later = (map_x_start > map_x || map_y_start < map_y);
+                    break;
+            }
+            if (!draw_later) {
                 draw_single_reservoir(x_start, y_start, has_water);
             }
         }

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -326,16 +326,16 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
             }
             switch (city_view_orientation()) {
                 case DIR_0_TOP:
-                    draw_later = (map_x_start > map_x || map_y_start > map_y);
+                    draw_later = map_x_start > map_x || map_y_start > map_y;
                     break;
                 case DIR_2_RIGHT:
-                    draw_later = (map_x_start < map_x || map_y_start > map_y);
+                    draw_later = map_x_start < map_x || map_y_start > map_y;
                     break;
                 case DIR_4_BOTTOM:
-                    draw_later = (map_x_start < map_x || map_y_start < map_y);
+                    draw_later = map_x_start < map_x || map_y_start < map_y;
                     break;
                 case DIR_6_LEFT:
-                    draw_later = (map_x_start > map_x || map_y_start < map_y);
+                    draw_later = map_x_start > map_x || map_y_start < map_y;
                     break;
             }
             if (!draw_later) {

--- a/src/widget/map_editor.c
+++ b/src/widget/map_editor.c
@@ -105,14 +105,13 @@ void widget_map_editor_draw(void)
 static void update_city_view_coords(const mouse *m, map_tile *tile)
 {
     view_tile view;
-    city_view_pixels_to_view_tile(m->x, m->y, &view);
-    tile->grid_offset = city_view_tile_to_grid_offset(&view);
-    city_view_set_selected_view_tile(&view);
-    if (tile->grid_offset) {
+    if (city_view_pixels_to_view_tile(m->x, m->y, &view)) {
+        tile->grid_offset = city_view_tile_to_grid_offset(&view);
+        city_view_set_selected_view_tile(&view);
         tile->x = map_grid_offset_to_x(tile->grid_offset);
         tile->y = map_grid_offset_to_y(tile->grid_offset);
     } else {
-        tile->x = tile->y = 0;
+        tile->grid_offset = tile->x = tile->y = 0;
     }
 }
 

--- a/src/widget/map_editor.c
+++ b/src/widget/map_editor.c
@@ -104,7 +104,10 @@ void widget_map_editor_draw(void)
 
 static void update_city_view_coords(const mouse *m, map_tile *tile)
 {
-    tile->grid_offset = city_view_pixels_to_grid_offset(m->x, m->y);
+    view_tile view;
+    city_view_pixels_to_view_tile(m->x, m->y, &view);
+    tile->grid_offset = city_view_tile_to_grid_offset(&view);
+    city_view_set_selected_view_tile(&view);
     if (tile->grid_offset) {
         tile->x = map_grid_offset_to_x(tile->grid_offset);
         tile->y = map_grid_offset_to_y(tile->grid_offset);


### PR DESCRIPTION
This change is specifically tailored to draggable reservoirs (where you build two reservoirs and an aqueduct simply by click-dragging).

The following changes were implemented:

- Makes aqueducts not turn towards every tile of the reservoir construction ghost, but only to those tiles that are aqueduct entrances
- Makes reservoir ghosts properly draw behind/in front of the other reservoir ghost
- Makes aqueducts show in front of the reservoir ghost
- Better display when reservoirs have water access: If one of the reservoirs is being built close to water, both will show as being filled

It's not perfect: some artifacts still exist regarding aqueducts, but they are less noticeable. Fixing those would require too many changes to the game for little difference, so I don't think it's worth the extra effort.