### PR TITLE
List 2000 saved games intead of just 200.

### DIFF
--- a/src/core/dir.c
+++ b/src/core/dir.c
@@ -61,13 +61,13 @@ static int listing_initialized = 0;
 static void clear_dir_listing(void)
 {
     if (!listing_initialized) {
-        for (int i = 0; i < DIR_MAX_FILES; i++) {
+        for (int i = 0; i < DIR_MAX_SAVE_FILES; i++) {
             listing.files[i] = malloc(FILE_NAME_MAX * sizeof(char));
         }
         listing_initialized = 1;
     }
     listing.num_files = 0;
-    for (int i = 0; i < DIR_MAX_FILES; i++) {
+    for (int i = 0; i < DIR_MAX_SAVE_FILES; i++) {
         listing.files[i][0] = 0;
     }
 }
@@ -87,7 +87,8 @@ const dir_listing *dir_find_files_with_extension(const char *extension)
     }
     fs_dir_entry *entry;
     struct stat file_info;
-    while ((entry = fs_dir_read(d)) && listing.num_files < DIR_MAX_FILES) {
+    int dir_max_files = !strcmp(extension, "sav") ? DIR_MAX_SAVE_FILES : DIR_MAX_FILES;
+    while ((entry = fs_dir_read(d)) && listing.num_files < dir_max_files) {
         const char *name = dir_entry_name(entry);
         if (stat(name, &file_info) != -1) {
             int m = file_info.st_mode;

--- a/src/core/dir.h
+++ b/src/core/dir.h
@@ -7,12 +7,13 @@
  */
 
 #define DIR_MAX_FILES 200
+#define DIR_MAX_SAVE_FILES (DIR_MAX_FILES * 10)
 
 /**
  * Directory listing
  */
 typedef struct {
-    char *files[DIR_MAX_FILES]; /**< Filenames in UTF-8 encoding */
+    char *files[DIR_MAX_SAVE_FILES]; /**< Filenames in UTF-8 encoding */
     int num_files; /**< Number of files in the list */
 } dir_listing;
 


### PR DESCRIPTION
Fixes #333 

Not sure if you will like it.
I decided to raise the limit only for saved games, because in the original you can still load the 201th by typing its name (as before) but in case of scenarios there is no such option.