### PR TITLE
Music restart fixes

### DIFF
--- a/src/game/file.c
+++ b/src/game/file.c
@@ -351,10 +351,10 @@ int game_file_load_saved_game(const char *filename)
     if (!game_file_io_read_saved_game(filename, 0)) {
         return 0;
     }
-    sound_music_update();
-    
     initialize_saved_game();
     building_storage_reset_building_ids();
+
+    sound_music_update();
     return 1;
 }
 

--- a/src/window/mission_briefing.c
+++ b/src/window/mission_briefing.c
@@ -174,6 +174,7 @@ static void button_start_mission(int param1, int param2)
 {
     sound_speech_stop();
     sound_music_reset();
+    sound_music_update();
     window_city_show();
     city_mission_reset_save_start();
 }


### PR DESCRIPTION
- Music is not restarted when loading a save from the main menu if the music to be played is the same as the main menu music
- Music sometimes restarted twice when loading a save because `initialize_saved_game()` calls `sound_music_reset()` after `sound_music_update()`
- Music is not started after selecting Replay Map in campaign mode