### PR TITLE
Android build preparation: disable setting windowed mode

### DIFF
--- a/src/city/view.c
+++ b/src/city/view.c
@@ -1,11 +1,11 @@
 #include "view.h"
 
 #include "core/direction.h"
+#include "graphics/menu.h"
 #include "map/grid.h"
 #include "map/image.h"
 #include "widget/minimap.h"
 
-#define MENUBAR_HEIGHT 24
 #define TILE_WIDTH_PIXELS 60
 #define TILE_HEIGHT_PIXELS 30
 #define HALF_TILE_WIDTH_PIXELS 30
@@ -359,12 +359,12 @@ static void set_viewport(int x_offset, int y_offset, int width, int height)
 
 static void set_viewport_with_sidebar(void)
 {
-    set_viewport(0, MENUBAR_HEIGHT, data.screen_width - 160, data.screen_height - MENUBAR_HEIGHT);
+    set_viewport(0, TOP_MENU_HEIGHT, data.screen_width - 160, data.screen_height - TOP_MENU_HEIGHT);
 }
 
 static void set_viewport_without_sidebar(void)
 {
-    set_viewport(0, MENUBAR_HEIGHT, data.screen_width - 40, data.screen_height - MENUBAR_HEIGHT);
+    set_viewport(0, TOP_MENU_HEIGHT, data.screen_width - 40, data.screen_height - TOP_MENU_HEIGHT);
 }
 
 void city_view_set_viewport(int screen_width, int screen_height)

--- a/src/game/system.h
+++ b/src/game/system.h
@@ -19,6 +19,12 @@ void system_resize(int width, int height);
 void system_center(void);
 
 /**
+ * Returns whether the window must always be fullscreen
+ * @return true when only fullscreen can be used, false otherwise
+ */
+int system_is_fullscreen_only(void);
+
+/**
  * Set fullscreen on/off
  */
 void system_set_fullscreen(int fullscreen);

--- a/src/graphics/menu.c
+++ b/src/graphics/menu.c
@@ -4,12 +4,16 @@
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 
+#define TOP_MENU_BASE_X_OFFSET 10
+#define MENU_BASE_TEXT_Y_OFFSET 6
+#define MENU_ITEM_HEIGHT 20
+
 void menu_bar_draw(menu_bar_item *items, int num_items)
 {
-    short x_offset = items[0].x_start;
+    short x_offset = TOP_MENU_BASE_X_OFFSET;
     for (int i = 0; i < num_items; i++) {
         items[i].x_start = x_offset;
-        x_offset += lang_text_draw(items[i].text_group, 0, x_offset, items[i].y_start, FONT_NORMAL_GREEN);
+        x_offset += lang_text_draw(items[i].text_group, 0, x_offset, MENU_BASE_TEXT_Y_OFFSET, FONT_NORMAL_GREEN);
         items[i].x_end = x_offset;
         x_offset += 32; // spacing
     }
@@ -20,8 +24,8 @@ static int get_menu_bar_item(const mouse *m, menu_bar_item *items, int num_items
     for (int i = 0; i < num_items; i++) {
         if (items[i].x_start <= m->x &&
             items[i].x_end > m->x &&
-            items[i].y_start <= m->y &&
-            items[i].y_start + 12 > m->y) {
+            MENU_BASE_TEXT_Y_OFFSET <= m->y &&
+            MENU_BASE_TEXT_Y_OFFSET + 12 > m->y) {
             return i + 1;
         }
     }
@@ -37,31 +41,40 @@ int menu_bar_handle_mouse(const mouse *m, menu_bar_item *items, int num_items, i
     return menu_id;
 }
 
-static void calculate_menu_width(menu_bar_item *menu)
+static void calculate_menu_dimensions(menu_bar_item *menu)
 {
     int max_width = 0;
+    int height_pixels = MENU_ITEM_HEIGHT;
     for (int i = 0; i < menu->num_items; i++) {
         menu_item *sub = &menu->items[i];
+        if (sub->hidden) {
+            continue;
+        }
         int width_pixels = lang_text_get_width(
             sub->text_group, sub->text_number, FONT_NORMAL_BLACK);
         if (width_pixels > max_width) {
             max_width = width_pixels;
         }
+        height_pixels += MENU_ITEM_HEIGHT;
     }
     int blocks = (max_width + 8) / 16 + 1; // 1 block padding
     menu->calculated_width_blocks = blocks < 10 ? 10 : blocks;
+    menu->calculated_height_blocks = height_pixels / 16;
 }
 
 void menu_draw(menu_bar_item *menu, int focus_item_id)
 {
-    if (menu->calculated_width_blocks == 0) {
-        calculate_menu_width(menu);
+    if (menu->calculated_width_blocks == 0 || menu->calculated_height_blocks == 0) {
+        calculate_menu_dimensions(menu);
     }
-    unbordered_panel_draw(menu->x_start, menu->y_start + 18,
-        menu->calculated_width_blocks, (20 + 20 * menu->num_items) / 16);
+    unbordered_panel_draw(menu->x_start, TOP_MENU_HEIGHT,
+        menu->calculated_width_blocks, menu->calculated_height_blocks);
+    int y_offset = TOP_MENU_HEIGHT + MENU_BASE_TEXT_Y_OFFSET * 2;
     for (int i = 0; i < menu->num_items; i++) {
         menu_item *sub = &menu->items[i];
-        int y_offset = 30 + menu->y_start + sub->y_start;
+        if (sub->hidden) {
+            continue;
+        }
         if (i == focus_item_id - 1) {
             graphics_fill_rect(menu->x_start, y_offset - 2,
                 16 * menu->calculated_width_blocks, 16, COLOR_BLACK);
@@ -71,18 +84,24 @@ void menu_draw(menu_bar_item *menu, int focus_item_id)
             lang_text_draw(sub->text_group, sub->text_number,
                 menu->x_start + 8, y_offset, FONT_NORMAL_BLACK);
         }
+        y_offset += MENU_ITEM_HEIGHT;
     }
 }
 
 static int get_menu_item(const mouse *m, menu_bar_item *menu)
 {
+    int y_offset = TOP_MENU_HEIGHT + MENU_BASE_TEXT_Y_OFFSET * 2;
     for (int i = 0; i < menu->num_items; i++) {
+        if (menu->items[i].hidden) {
+            continue;
+        }
         if (menu->x_start <= m->x &&
             menu->x_start + 16 * menu->calculated_width_blocks > m->x &&
-            menu->y_start + menu->items[i].y_start + 30 <= m->y &&
-            menu->y_start + menu->items[i].y_start + 45 > m->y) {
+            y_offset <= m->y &&
+            y_offset + 15 > m->y) {
             return i + 1;
         }
+        y_offset += MENU_ITEM_HEIGHT;
     }
     return 0;
 }

--- a/src/graphics/menu.h
+++ b/src/graphics/menu.h
@@ -3,22 +3,24 @@
 
 #include "input/mouse.h"
 
+#define TOP_MENU_HEIGHT 24
+
 typedef struct {
-    short y_start;
     short text_group;
     short text_number;
     void (*left_click_handler)(int param);
     int parameter;
+    int hidden;
 } menu_item;
 
 typedef struct {
-    short x_start;
-    short x_end;
-    short y_start;
     short text_group;
     menu_item *items;
     int num_items;
+    short x_start;
+    short x_end;
     int calculated_width_blocks;
+    int calculated_height_blocks;
 } menu_bar_item;
 
 void menu_bar_draw(menu_bar_item *items, int num_items);

--- a/src/graphics/screenshot.c
+++ b/src/graphics/screenshot.c
@@ -7,6 +7,7 @@
 #include "core/log.h"
 #include "graphics/screen.h"
 #include "graphics/graphics.h"
+#include "graphics/menu.h"
 #include "graphics/window.h"
 #include "map/grid.h"
 #include "widget/city_without_overlay.h"
@@ -18,7 +19,6 @@
 #include <string.h>
 #include <time.h>
 
-#define TOP_MENU_HEIGHT 24
 #define TILE_X_SIZE 60
 #define TILE_Y_SIZE 30
 #define IMAGE_HEIGHT_CHUNK TILE_Y_SIZE

--- a/src/platform/switch/screen.c
+++ b/src/platform/switch/screen.c
@@ -3,6 +3,7 @@
 #include "SDL.h"
 
 #include "game/settings.h"
+#include "game/system.h"
 #include "graphics/graphics.h"
 #include "graphics/screen.h"
 #include "input/mouse.h"
@@ -157,4 +158,9 @@ void platform_screen_render(void)
     SDL_RenderCopy(SDL.renderer, current_cursor->texture, NULL, &dst);
 
     SDL_RenderPresent(SDL.renderer);
+}
+
+int system_is_fullscreen_only(void)
+{
+    return 1;
 }

--- a/src/platform/vita/screen.c
+++ b/src/platform/vita/screen.c
@@ -1,6 +1,7 @@
 #include "platform/screen.h"
 #include "input/mouse.h"
 #include "game/settings.h"
+#include "game/system.h"
 #include "graphics/graphics.h"
 #include "graphics/screen.h"
 
@@ -80,4 +81,9 @@ void platform_screen_render(void)
     vita2d_end_drawing();
     vita2d_wait_rendering_done();
     vita2d_swap_buffers();
+}
+
+int system_is_fullscreen_only(void)
+{
+    return 1;
 }

--- a/src/widget/sidebar.c
+++ b/src/widget/sidebar.c
@@ -20,6 +20,7 @@
 #include "graphics/image.h"
 #include "graphics/image_button.h"
 #include "graphics/lang_text.h"
+#include "graphics/menu.h"
 #include "graphics/panel.h"
 #include "graphics/screen.h"
 #include "graphics/text.h"
@@ -355,9 +356,9 @@ static void draw_extra_info_buttons(int x_offset, int is_collapsed)
         return;
     }
 
-    graphics_set_clip_rectangle(x_offset, 24,
+    graphics_set_clip_rectangle(x_offset, TOP_MENU_HEIGHT,
             screen_width() - x_offset,
-            screen_height() - 24);
+            screen_height() - TOP_MENU_HEIGHT);
 
     if (update_extra_info(extra_info_height, 0)) {
         draw_extra_info_panel(x_offset, extra_info_height);
@@ -615,7 +616,7 @@ static void draw_sliding_foreground(void)
 
     int x_offset_expanded = get_x_offset_expanded();
     int x_offset_collapsed = get_x_offset_collapsed();
-    graphics_set_clip_rectangle(x_offset_expanded, 24, SIDEBAR_EXPANDED_WIDTH, screen_height() - 24);
+    graphics_set_clip_rectangle(x_offset_expanded, TOP_MENU_HEIGHT, SIDEBAR_EXPANDED_WIDTH, screen_height() - TOP_MENU_HEIGHT);
 
     int image_base = image_group(GROUP_SIDE_PANEL);
     // draw collapsed sidebar

--- a/src/widget/top_menu.c
+++ b/src/widget/top_menu.c
@@ -57,49 +57,49 @@ static void menu_help_about(int param);
 static void menu_advisors_go_to(int advisor);
 
 static menu_item menu_file[] = {
-    {0, 1, 1, menu_file_new_game, 0},
-    {20, 1, 2, menu_file_replay_map, 0},
-    {40, 1, 3, menu_file_load_game, 0},
-    {60, 1, 4, menu_file_save_game, 0},
-    {80, 1, 6, menu_file_delete_game, 0},
-    {100, 1, 5, menu_file_exit_game, 0},
+    {1, 1, menu_file_new_game, 0},
+    {1, 2, menu_file_replay_map, 0},
+    {1, 3, menu_file_load_game, 0},
+    {1, 4, menu_file_save_game, 0},
+    {1, 6, menu_file_delete_game, 0},
+    {1, 5, menu_file_exit_game, 0},
 };
 
 static menu_item menu_options[] = {
-    {0, 2, 1, menu_options_display, 0},
-    {20, 2, 2, menu_options_sound, 0},
-    {40, 2, 3, menu_options_speed, 0},
-    {60, 2, 6, menu_options_difficulty, 0},
-    {80, 19, 51, menu_options_autosave, 0},
+    {2, 1, menu_options_display, 0},
+    {2, 2, menu_options_sound, 0},
+    {2, 3, menu_options_speed, 0},
+    {2, 6, menu_options_difficulty, 0},
+    {19, 51, menu_options_autosave, 0},
 };
 
 static menu_item menu_help[] = {
-    {0, 3, 1, menu_help_help, 0},
-    {20, 3, 2, menu_help_mouse_help, 0},
-    {40, 3, 5, menu_help_warnings, 0},
-    {60, 3, 7, menu_help_about, 0},
+    {3, 1, menu_help_help, 0},
+    {3, 2, menu_help_mouse_help, 0},
+    {3, 5, menu_help_warnings, 0},
+    {3, 7, menu_help_about, 0},
 };
 
 static menu_item menu_advisors[] = {
-    {0, 4, 1, menu_advisors_go_to, 1},
-    {20, 4, 2, menu_advisors_go_to, 2},
-    {40, 4, 3, menu_advisors_go_to, 3},
-    {60, 4, 4, menu_advisors_go_to, 4},
-    {80, 4, 5, menu_advisors_go_to, 5},
-    {100, 4, 6, menu_advisors_go_to, 6},
-    {120, 4, 7, menu_advisors_go_to, 7},
-    {140, 4, 8, menu_advisors_go_to, 8},
-    {160, 4, 9, menu_advisors_go_to, 9},
-    {180, 4, 10, menu_advisors_go_to, 10},
-    {200, 4, 11, menu_advisors_go_to, 11},
-    {220, 4, 12, menu_advisors_go_to, 12},
+    {4, 1, menu_advisors_go_to, 1},
+    {4, 2, menu_advisors_go_to, 2},
+    {4, 3, menu_advisors_go_to, 3},
+    {4, 4, menu_advisors_go_to, 4},
+    {4, 5, menu_advisors_go_to, 5},
+    {4, 6, menu_advisors_go_to, 6},
+    {4, 7, menu_advisors_go_to, 7},
+    {4, 8, menu_advisors_go_to, 8},
+    {4, 9, menu_advisors_go_to, 9},
+    {4, 10, menu_advisors_go_to, 10},
+    {4, 11, menu_advisors_go_to, 11},
+    {4, 12, menu_advisors_go_to, 12},
 };
 
 static menu_bar_item menu[] = {
-    {10, 0, 6, 1, menu_file, 6},
-    {10, 0, 6, 2, menu_options, 5},
-    {10, 0, 6, 3, menu_help, 4},
-    {10, 0, 6, 4, menu_advisors, 12},
+    {1, menu_file, 6},
+    {2, menu_options, 5},
+    {3, menu_help, 4},
+    {4, menu_advisors, 12},
 };
 
 static const int INDEX_OPTIONS = 1;
@@ -113,7 +113,7 @@ static struct {
     int open_sub_menu;
     int focus_menu_id;
     int focus_sub_menu_id;
-} data = {0, 0, 0, 0, 0, 0};
+} data;
 
 static struct {
     int population;
@@ -157,8 +157,9 @@ static void set_text_for_warnings(void)
     menu_update_text(&menu[INDEX_HELP], 2, setting_warnings() ? 6 : 5);
 }
 
-static void init_from_settings(void)
+static void init(void)
 {
+    menu[INDEX_OPTIONS].items[0].hidden = system_is_fullscreen_only();
     set_text_for_autosave();
     set_text_for_tooltips();
     set_text_for_warnings();
@@ -192,7 +193,7 @@ static void top_menu_window_show(void)
         handle_mouse,
         0
     };
-    init_from_settings();
+    init();
     window_show(&window);
 }
 

--- a/src/widget/top_menu_editor.c
+++ b/src/widget/top_menu_editor.c
@@ -38,40 +38,42 @@ static void menu_resets_invasions(int param);
 static void menu_empire_choose(int param);
 
 static menu_item menu_file[] = {
-    {0, 7, 1, menu_file_new_map, 0},
-    {20, 7, 2, menu_file_load_map, 0},
-    {40, 7, 3, menu_file_save_map, 0},
-    {60, 7, 4, menu_file_exit_editor, 0},
+    {7, 1, menu_file_new_map, 0},
+    {7, 2, menu_file_load_map, 0},
+    {7, 3, menu_file_save_map, 0},
+    {7, 4, menu_file_exit_editor, 0},
 };
 
 static menu_item menu_options[] = {
-    {0, 2, 1, menu_options_display, 0},
-    {20, 2, 2, menu_options_sound, 0},
-    {40, 2, 3, menu_options_speed, 0},
+    {2, 1, menu_options_display, 0},
+    {2, 2, menu_options_sound, 0},
+    {2, 3, menu_options_speed, 0},
 };
 
 static menu_item menu_help[] = {
-    {0, 3, 1, menu_help_help, 0},
-    {20, 3, 7, menu_help_about, 0},
+    {3, 1, menu_help_help, 0},
+    {3, 7, menu_help_about, 0},
 };
 
 static menu_item menu_resets[] = {
-    {0, 10, 1, menu_resets_herds, 0},
-    {20, 10, 2, menu_resets_fish, 0},
-    {40, 10, 3, menu_resets_invasions, 0},
+    {10, 1, menu_resets_herds, 0},
+    {10, 2, menu_resets_fish, 0},
+    {10, 3, menu_resets_invasions, 0},
 };
 
 static menu_item menu_empire[] = {
-    {0, 149, 1, menu_empire_choose, 0},
+    {149, 1, menu_empire_choose, 0},
 };
 
 static menu_bar_item menu[] = {
-    {10, 0, 6, 7, menu_file, 4},
-    {10, 0, 6, 2, menu_options, 3},
-    {10, 0, 6, 3, menu_help, 2},
-    {10, 0, 6, 10, menu_resets, 3},
-    {10, 0, 6, 149, menu_empire, 1},
+    {7, menu_file, 4},
+    {2, menu_options, 3},
+    {3, menu_help, 2},
+    {10, menu_resets, 3},
+    {149, menu_empire, 1},
 };
+
+#define INDEX_OPTIONS 1
 
 static struct {
     int open_sub_menu;
@@ -84,6 +86,11 @@ static void clear_state(void)
     data.open_sub_menu = 0;
     data.focus_menu_id = 0;
     data.focus_sub_menu_id = 0;
+}
+
+static void init(void)
+{
+    menu[INDEX_OPTIONS].items[0].hidden = system_is_fullscreen_only();
 }
 
 static void draw_foreground(void)
@@ -109,6 +116,7 @@ static void top_menu_window_show(void)
         handle_mouse,
         0
     };
+    init();
     window_show(&window);
 }
 


### PR DESCRIPTION
Already works for Vita and Switch.

This is a change I'm unsure about as it adds a `definitions.h` file to `platform`, allowing global platform-related settings. It's used both for forcing full-screen and for implementing virtual keyboard support, which is coming next.

This also implements a `disabled` parameter to the top menu. When fullscreen is forced, the `Display settings` menu is disabled (grayed out) and the keyboard shortcuts for resizing the window don't work.