### PR TITLE
Android build preparation: Improved touch support

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -407,10 +407,14 @@ int building_construction_is_updatable(void)
 void building_construction_cancel(void)
 {
     map_property_clear_constructing_and_deleted();
-    if (building_construction_is_updatable()) {
-        game_undo_restore_map(1);
+    if (data.in_progress && building_construction_is_updatable()) {
+        if (building_construction_is_updatable()) {
+            game_undo_restore_map(1);
+        }
+        data.in_progress = 0;
+    } else {
+        building_construction_set_type(BUILDING_NONE);
     }
-    data.in_progress = 0;
 }
 
 void building_construction_update(int x, int y, int grid_offset)

--- a/src/editor/tool.c
+++ b/src/editor/tool.c
@@ -45,7 +45,12 @@ int editor_tool_is_active(void)
 
 void editor_tool_deactivate(void)
 {
-    data.active = 0;
+    if (editor_tool_is_updatable() && data.build_in_progress) {
+        game_undo_restore_map(1);
+        data.build_in_progress = 0;
+    } else {
+        data.active = 0;
+    }
 }
 
 void editor_tool_set_type(tool_type type)
@@ -90,6 +95,11 @@ void editor_tool_foreach_brush_tile(void (*callback)(const void *user_data, int 
     }
 }
 
+int editor_tool_is_updatable(void)
+{
+    return data.type == TOOL_ROAD;
+}
+
 int editor_tool_is_in_use(void)
 {
     return data.build_in_progress;
@@ -109,9 +119,9 @@ void editor_tool_start_use(const map_tile *tile)
     }
 }
 
-static int is_brush(tool_type type)
+int editor_tool_is_brush(void)
 {
-    switch (type) {
+    switch (data.type) {
         case TOOL_GRASS:
         case TOOL_TREES:
         case TOOL_WATER:
@@ -226,7 +236,7 @@ void editor_tool_update_use(const map_tile *tile)
         building_construction_place_road(1, data.start_tile.x, data.start_tile.y, tile->x, tile->y);
         return;
     }
-    if (!is_brush(data.type)) {
+    if (!editor_tool_is_brush()) {
         return;
     }
 

--- a/src/editor/tool.h
+++ b/src/editor/tool.h
@@ -33,9 +33,12 @@ void editor_tool_deactivate(void);
 void editor_tool_set_type(tool_type tool);
 void editor_tool_set_with_id(tool_type tool, int id);
 
+int editor_tool_is_brush(void);
 int editor_tool_brush_size(void);
 void editor_tool_set_brush_size(int size);
 void editor_tool_foreach_brush_tile(void (*callback)(const void *user_data, int dx, int dy), const void *user_data);
+
+int editor_tool_is_updatable(void);
 
 int editor_tool_is_in_use(void);
 

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -189,7 +189,7 @@ static int get_elapsed_ticks(void)
     if (building_construction_in_progress()) {
         return 0;
     }
-    if (scroll_in_progress()) {
+    if (scroll_in_progress() && !scroll_is_smooth()) {
         return 0;
     }
 

--- a/src/graphics/menu.c
+++ b/src/graphics/menu.c
@@ -76,8 +76,8 @@ void menu_draw(menu_bar_item *menu, int focus_item_id)
             continue;
         }
         if (i == focus_item_id - 1) {
-            graphics_fill_rect(menu->x_start, y_offset - 2,
-                16 * menu->calculated_width_blocks, 16, COLOR_BLACK);
+            graphics_fill_rect(menu->x_start, y_offset - 4,
+                16 * menu->calculated_width_blocks, 20, COLOR_BLACK);
             lang_text_draw_colored(sub->text_group, sub->text_number,
                 menu->x_start + 8, y_offset, FONT_NORMAL_PLAIN, COLOR_ORANGE);
         } else {
@@ -97,8 +97,8 @@ static int get_menu_item(const mouse *m, menu_bar_item *menu)
         }
         if (menu->x_start <= m->x &&
             menu->x_start + 16 * menu->calculated_width_blocks > m->x &&
-            y_offset <= m->y &&
-            y_offset + 15 > m->y) {
+            y_offset - 2 <= m->y &&
+            y_offset + 19 > m->y) {
             return i + 1;
         }
         y_offset += MENU_ITEM_HEIGHT;

--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -30,7 +30,7 @@ static void clear_mouse_button(mouse_button *button)
     button->system_change = SYSTEM_NONE;
 }
 
-void mouse_set_from_touch(const touch *first)
+void mouse_set_from_touch(const touch *first, const touch *last)
 {
     data.x = first->current_point.x;
     data.y = first->current_point.y;
@@ -100,6 +100,7 @@ static void update_button_state(mouse_button *button)
     button->double_click = (button->system_change & SYSTEM_DOUBLE_CLICK) == SYSTEM_DOUBLE_CLICK;
     button->system_change = SYSTEM_NONE;
     button->is_down = (button->is_down || button->went_down) && !button->went_up;
+    button->double_click = 0;
 }
 
 void mouse_determine_button_state(void)

--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -21,7 +21,16 @@ const mouse *mouse_get(void)
     return &data;
 }
 
-void mouse_set_from_touch(const touch *first, const touch *last)
+static void clear_mouse_button(mouse_button *button)
+{
+    button->is_down = 0;
+    button->went_down = 0;
+    button->went_up = 0;
+    button->double_click = 0;
+    button->system_change = SYSTEM_NONE;
+}
+
+void mouse_set_from_touch(const touch *first)
 {
     data.x = first->current_point.x;
     data.y = first->current_point.y;
@@ -32,25 +41,19 @@ void mouse_set_from_touch(const touch *first, const touch *last)
     data.left.system_change = SYSTEM_NONE;
     data.right.system_change = SYSTEM_NONE;
 
-    if (!touch_is_scroll()) {
-        data.left.is_down = (!first->has_ended && first->in_use);
-        data.left.went_down = first->has_started;
-        data.left.went_up = first->has_ended;
-        data.left.double_click = touch_was_double_click(first);
-
-        data.right.is_down = (!last->has_ended && last->in_use);
-        data.right.went_down = last->has_started;
-        data.right.went_up = last->has_ended;
-    } else {
-        data.left.is_down = 0;
-        data.left.went_down = 0;
-        data.left.went_up = 0;
-        data.left.double_click = 0;
-
-        data.right.is_down = 0;
-        data.right.went_down = 0;
-        data.right.went_up = 0;
+    if (touch_is_scroll()) {
+        mouse_reset_button_state();
+        return;
     }
+
+    data.left.is_down = (!first->has_ended && first->in_use);
+    data.left.went_down = first->has_started;
+    data.left.went_up = first->has_ended;
+    data.left.double_click = touch_was_double_click(first);
+
+    data.right.is_down = (!last->has_ended && last->in_use);
+    data.right.went_down = last->has_started;
+    data.right.went_up = last->has_ended;
 }
 
 void mouse_set_position(int x, int y)
@@ -126,17 +129,8 @@ void mouse_reset_up_state(void)
 void mouse_reset_button_state(void)
 {
     last_click = 0;
-
-    data.left.is_down = 0;
-    data.left.went_down = 0;
-    data.left.went_up = 0;
-    data.left.double_click = 0;
-    data.left.system_change = SYSTEM_NONE;
-
-    data.right.is_down = 0;
-    data.right.went_down = 0;
-    data.right.went_up = 0;
-    data.right.system_change = SYSTEM_NONE;
+    clear_mouse_button(&data.left);
+    clear_mouse_button(&data.right);
 }
 
 const mouse *mouse_in_dialog(const mouse *m)

--- a/src/input/mouse.h
+++ b/src/input/mouse.h
@@ -62,9 +62,8 @@ void mouse_set_inside_window(int inside);
 /**
  * Changes the mouse information from touch information
  * @param first The first touch
- * @param last The last touch
  */
-void mouse_set_from_touch(const touch *first, const touch *last);
+void mouse_set_from_touch(const touch *first);
 
 void mouse_reset_up_state(void);
 

--- a/src/input/mouse.h
+++ b/src/input/mouse.h
@@ -63,7 +63,7 @@ void mouse_set_inside_window(int inside);
  * Changes the mouse information from touch information
  * @param first The first touch
  */
-void mouse_set_from_touch(const touch *first);
+void mouse_set_from_touch(const touch *first, const touch *last);
 
 void mouse_reset_up_state(void);
 

--- a/src/input/scroll.c
+++ b/src/input/scroll.c
@@ -126,6 +126,11 @@ static int get_scroll_speed_factor(void)
     return calc_bound((100 - setting_scroll_speed()) / 10, 0, 10);
 }
 
+int scroll_is_smooth(void)
+{
+    return config_get(CONFIG_UI_SMOOTH_SCROLLING) || data.is_touch || data.speed.decaying;
+}
+
 static int should_scroll(void)
 {
     time_millis current_time = time_get_millis();
@@ -251,13 +256,15 @@ int scroll_move_touch_drag(int original_x, int original_y, int current_x, int cu
     return 0;
 }
 
-void scroll_end_touch_drag(void)
+void scroll_end_touch_drag(int do_decay)
 {
     data.is_touch = 0;
-    data.speed.last_position.x = data.position.current.x + data.speed.x;
-    data.speed.last_position.y = data.position.current.y + data.speed.y;
-    data.speed.last_time = time_get_millis();
-    data.speed.decaying = 1;
+    if (do_decay) {
+        data.speed.last_position.x = data.position.current.x + data.speed.x;
+        data.speed.last_position.y = data.position.current.y + data.speed.y;
+        data.speed.last_time = time_get_millis();
+        data.speed.decaying = 1;
+    }
 }
 
 int scroll_decay(pixel_offset *position)

--- a/src/input/scroll.h
+++ b/src/input/scroll.h
@@ -12,6 +12,7 @@ typedef enum {
 } scroll_type;
 
 int scroll_in_progress(void);
+int scroll_is_smooth(void);
 
 int scroll_get_direction(const mouse *m);
 
@@ -22,7 +23,7 @@ void scroll_get_delta(const mouse *m, pixel_offset *delta, scroll_type type);
 
 void scroll_start_touch_drag(const pixel_offset *position, touch_coords coords);
 int scroll_move_touch_drag(int original_x, int original_y, int current_x, int current_y, pixel_offset *position);
-void scroll_end_touch_drag(void);
+void scroll_end_touch_drag(int do_decay);
 int scroll_decay(pixel_offset *position);
 touch_coords scroll_get_original_touch_position(void);
 

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -202,6 +202,6 @@ int touch_to_mouse(void)
         }
         return 0;
     }
-    mouse_set_from_touch(first, get_latest_touch());
+    mouse_set_from_touch(first);
     return 1;
 }

--- a/src/input/touch.c
+++ b/src/input/touch.c
@@ -202,6 +202,6 @@ int touch_to_mouse(void)
         }
         return 0;
     }
-    mouse_set_from_touch(first);
+    mouse_set_from_touch(first, get_latest_touch());
     return 1;
 }

--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -199,7 +199,7 @@ static int touch_in_city(const touch *t)
     return (coords.x >= 0 && coords.x < width && coords.y >= 0 && coords.y < height);
 }
 
-static void widget_city_handle_touch_scroll(const touch *t)
+static void handle_touch_scroll(const touch *t)
 {
     if (building_construction_type()) {
         if (t->has_started) {
@@ -240,7 +240,7 @@ static void widget_city_handle_touch_scroll(const touch *t)
     }
 }
 
-static void widget_city_handle_last_touch(void)
+static void handle_last_touch(void)
 {
     const touch *last = get_latest_touch();
     if (last->in_use && touch_was_click(last)) {
@@ -266,7 +266,7 @@ static int handle_cancel_construction_button(const touch *t)
     return 1;
 }
 
-static void widget_city_handle_first_touch(map_tile *tile)
+static void handle_first_touch(map_tile *tile)
 {
     const touch *first = get_earliest_touch();
 
@@ -282,7 +282,7 @@ static void widget_city_handle_first_touch(map_tile *tile)
         }
     }
 
-    widget_city_handle_touch_scroll(first);
+    handle_touch_scroll(first);
 
     if (!touch_in_city(first)) {
         return;
@@ -334,7 +334,7 @@ static void widget_city_handle_first_touch(map_tile *tile)
     }
 }
 
-static void widget_city_handle_touch(void)
+static void handle_touch(void)
 {
     const touch *first = get_earliest_touch();
     if (!first->in_use) {
@@ -352,8 +352,8 @@ static void widget_city_handle_touch(void)
         scroll_restore_margins();
     }
 
-    widget_city_handle_last_touch();
-    widget_city_handle_first_touch(tile);
+    handle_last_touch();
+    handle_first_touch(tile);
 
     if (first->has_ended) {
         data.capture_input = 0;
@@ -371,7 +371,7 @@ void widget_city_handle_mouse(const mouse *m)
 {
     scroll_map(m);
     if (m->is_touch) {
-        widget_city_handle_touch();
+        handle_touch();
         return;
     }
     map_tile *tile = &data.current_tile;
@@ -434,7 +434,7 @@ void widget_city_handle_mouse_military(const mouse *m, int legion_formation_id)
         if (t->has_started) {
             data.capture_input = 1;
         }
-        widget_city_handle_touch_scroll(t);
+        handle_touch_scroll(t);
         if (t->has_ended) {
             data.capture_input = 0;
         }

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -753,6 +753,9 @@ int city_building_ghost_mark_deleting(const map_tile *tile)
         scroll_in_progress() || construction_type != BUILDING_CLEAR_LAND) {
         return (construction_type == BUILDING_CLEAR_LAND);
     }
+    if (!building_construction_in_progress()) {
+        map_property_clear_constructing_and_deleted();
+    }
     map_building_tiles_mark_deleting(tile->grid_offset);
     return 1;
 }

--- a/src/widget/city_with_overlay.c
+++ b/src/widget/city_with_overlay.c
@@ -494,11 +494,6 @@ static void deletion_draw_animations(int x, int y, int grid_offset)
     draw_animation(x, y, grid_offset);
 }
 
-static void clear_deleted(int x, int y, int grid_offset)
-{
-    map_property_clear_deleted(grid_offset);
-}
-
 void city_with_overlay_draw(const map_tile *tile)
 {
     if (!select_city_overlay()) {
@@ -520,7 +515,6 @@ void city_with_overlay_draw(const map_tile *tile)
         city_view_foreach_map_tile(deletion_draw_terrain_top);
         city_view_foreach_map_tile(deletion_draw_animations);
         city_view_foreach_map_tile(draw_elevated_figures);
-        city_view_foreach_map_tile(clear_deleted);
     }
 }
 

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -458,11 +458,6 @@ static void deletion_draw_remaining(int x, int y, int grid_offset)
     draw_hippodrome_ornaments(x, y, grid_offset);
 }
 
-static void clear_deleted(int x, int y, int grid_offset)
-{
-    map_property_clear_deleted(grid_offset);
-}
-
 void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_coord, const map_tile *tile)
 {
     init_draw_context(selected_figure_id, figure_coord);
@@ -486,6 +481,5 @@ void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_
         city_view_foreach_map_tile(deletion_draw_terrain_top);
         city_view_foreach_map_tile(deletion_draw_figures_animations);
         city_view_foreach_map_tile(deletion_draw_remaining);
-        city_view_foreach_map_tile(clear_deleted);
     }
 }

--- a/src/widget/map_editor.c
+++ b/src/widget/map_editor.c
@@ -17,6 +17,9 @@
 
 static struct {
     map_tile current_tile;
+    int selected_grid_offset;
+    int new_start_grid_offset;
+    int capture_input;
 } data;
 
 static struct {
@@ -102,10 +105,10 @@ void widget_map_editor_draw(void)
     graphics_reset_clip_rectangle();
 }
 
-static void update_city_view_coords(const mouse *m, map_tile *tile)
+static void update_city_view_coords(int x, int y, map_tile *tile)
 {
     view_tile view;
-    if (city_view_pixels_to_view_tile(m->x, m->y, &view)) {
+    if (city_view_pixels_to_view_tile(x, y, &view)) {
         tile->grid_offset = city_view_tile_to_grid_offset(&view);
         city_view_set_selected_view_tile(&view);
         tile->x = map_grid_offset_to_x(tile->grid_offset);
@@ -121,23 +124,213 @@ static void scroll_map(const mouse *m)
     scroll_get_delta(m, &delta, SCROLL_TYPE_CITY);
     if (city_view_scroll(delta.x, delta.y)) {
         sound_city_decay_views();
+    } else {
+        pixel_offset position;
+        if (scroll_decay(&position)) {
+            city_view_set_camera_from_pixel_position(position.x, position.y);
+            sound_city_decay_views();
+        }
+    }
+}
+
+static int touch_in_map(const touch *t)
+{
+    int x_offset, y_offset, width, height;
+    city_view_get_viewport(&x_offset, &y_offset, &width, &height);
+
+    touch_coords coords = t->current_point;
+    coords.x -= x_offset;
+    coords.y -= y_offset;
+
+    return (coords.x >= 0 && coords.x < width && coords.y >= 0 && coords.y < height);
+}
+
+static void handle_touch_scroll(const touch *t)
+{
+    if (editor_tool_is_active()) {
+        if (t->has_started) {
+            int x_offset, y_offset, width, height;
+            city_view_get_viewport(&x_offset, &y_offset, &width, &height);
+            scroll_set_custom_margins(x_offset, y_offset, width, height);
+        }
+        if (t->has_ended) {
+            scroll_restore_margins();
+        }
+        return;
+    }
+    scroll_restore_margins();
+    pixel_offset camera_pixel_position;
+
+    if (!data.capture_input) {
+        return;
+    }
+    int was_click = touch_was_click(get_latest_touch());
+    if (t->has_started || was_click) {
+        city_view_get_camera_in_pixels(&camera_pixel_position.x, &camera_pixel_position.y);
+        scroll_start_touch_drag(&camera_pixel_position, (was_click) ? t->current_point : t->start_point);
+        return;
+    }
+
+    if (!touch_not_click(t)) {
+        return;
+    }
+
+    touch_coords original = scroll_get_original_touch_position();
+    if (scroll_move_touch_drag(original.x, original.y, t->current_point.x, t->current_point.y, &camera_pixel_position)) {
+        city_view_set_camera_from_pixel_position(camera_pixel_position.x, camera_pixel_position.y);
+        sound_city_decay_views();
+    }
+
+    if (t->has_ended) {
+        scroll_end_touch_drag(1);
+    }
+}
+
+static void handle_last_touch(void)
+{
+    const touch *last = get_latest_touch();
+    if (last->in_use && touch_was_click(last)) {
+        editor_tool_deactivate();
+    }
+}
+
+static int handle_cancel_construction_button(const touch *t)
+{
+    if (!editor_tool_is_active()) {
+        return 0;
+    }
+    int x, y, width, height;
+    city_view_get_viewport(&x, &y, &width, &height);
+    int box_size = 5 * 16;
+    width -= box_size;
+
+    if (t->current_point.x < width || t->current_point.x >= width + box_size ||
+        t->current_point.y < 24 || t->current_point.y >= 40 + box_size) {
+        return 0;
+    }
+    editor_tool_deactivate();
+    return 1;
+}
+
+static void handle_first_touch(map_tile *tile)
+{
+    const touch *first = get_earliest_touch();
+
+    if (touch_was_click(first)) {
+        if (handle_cancel_construction_button(first)) {
+            return;
+        }
+    }
+
+    handle_touch_scroll(first);
+
+    if (!touch_in_map(first)) {
+        return;
+    }
+
+    if (editor_tool_is_updatable()) {
+        if (!editor_tool_is_in_use()) {
+            if (first->has_started) {
+                editor_tool_start_use(tile);
+                data.new_start_grid_offset = 0;
+            }
+        } else {
+            if (first->has_started) {
+                if (data.selected_grid_offset != tile->grid_offset) {
+                    data.new_start_grid_offset = tile->grid_offset;
+                }
+            }
+            if (touch_not_click(first) && data.new_start_grid_offset) {
+                data.new_start_grid_offset = 0;
+                data.selected_grid_offset = 0;
+                editor_tool_deactivate();
+                editor_tool_start_use(tile);
+            }
+            editor_tool_update_use(tile);
+            if (data.selected_grid_offset != tile->grid_offset) {
+                data.selected_grid_offset = 0;
+            }
+            if (first->has_ended) {
+                if (data.selected_grid_offset == tile->grid_offset) {
+                    editor_tool_end_use(tile);
+                    widget_map_editor_clear_current_tile();
+                    data.new_start_grid_offset = 0;
+                } else {
+                    data.selected_grid_offset = tile->grid_offset;
+                }
+            }
+        }
+        return;
+    }
+
+    if (editor_tool_is_brush()) {
+        if (first->has_started) {
+            editor_tool_start_use(tile);
+        }
+        editor_tool_update_use(tile);
+        if (first->has_ended) {
+            editor_tool_end_use(tile);
+        }
+        return;
+    }
+
+    if (touch_was_click(first) && first->has_ended && data.capture_input &&
+        data.selected_grid_offset == tile->grid_offset) {
+        editor_tool_start_use(tile);
+        editor_tool_update_use(tile);
+        editor_tool_end_use(tile);
+        widget_map_editor_clear_current_tile();
+    } else if (first->has_ended) {
+        data.selected_grid_offset = tile->grid_offset;
+    }
+}
+
+static void handle_touch(void)
+{
+    const touch *first = get_earliest_touch();
+    if (!first->in_use) {
+        scroll_restore_margins();
+        return;
+    }
+
+    map_tile *tile = &data.current_tile;
+    if (!editor_tool_is_in_use() || touch_in_map(first)) {
+        update_city_view_coords(first->current_point.x, first->current_point.y, tile);
+    }
+
+    if (first->has_started && touch_in_map(first)) {
+        data.capture_input = 1;
+        scroll_restore_margins();
+    }
+
+    handle_last_touch();
+    handle_first_touch(tile);
+
+    if (first->has_ended) {
+        data.capture_input = 0;
     }
 }
 
 void widget_map_editor_handle_mouse(const mouse *m)
 {
     scroll_map(m);
+    if (m->is_touch) {
+        handle_touch();
+        return;
+    }
     map_tile *tile = &data.current_tile;
-    update_city_view_coords(m, tile);
+    update_city_view_coords(m->x, m->y, tile);
 
     if (!tile->grid_offset) {
         return;
     }
 
     if (m->left.went_down) {
-        editor_tool_start_use(tile);
+        if (!editor_tool_is_in_use()) {
+            editor_tool_start_use(tile);
+        }
         editor_tool_update_use(tile);
-    } else if (m->left.is_down) {
+    } else if (m->left.is_down || editor_tool_is_in_use()) {
         editor_tool_update_use(tile);
     }
     if (m->left.went_up) {
@@ -147,4 +340,10 @@ void widget_map_editor_handle_mouse(const mouse *m)
     if (m->right.went_up) {
         editor_tool_deactivate();
     }
+}
+
+void widget_map_editor_clear_current_tile(void)
+{
+    data.selected_grid_offset = 0;
+    data.current_tile.grid_offset = 0;
 }

--- a/src/widget/map_editor.h
+++ b/src/widget/map_editor.h
@@ -7,4 +7,6 @@ void widget_map_editor_draw(void);
 
 void widget_map_editor_handle_mouse(const mouse *m);
 
+void widget_map_editor_clear_current_tile(void);
+
 #endif // WIDGET_MAP_EDITOR_H

--- a/src/widget/sidebar_editor.c
+++ b/src/widget/sidebar_editor.c
@@ -14,8 +14,8 @@
 #include "scenario/editor_events.h"
 #include "scenario/editor_map.h"
 #include "scenario/map.h"
+#include "widget/map_editor.h"
 #include "widget/minimap.h"
-
 #include "window/editor/attributes.h"
 #include "window/editor/build_menu.h"
 #include "window/editor/map.h"
@@ -202,6 +202,7 @@ static void button_attributes(int show, int param2)
 
 static void button_build_tool(int tool, int param2)
 {
+    widget_map_editor_clear_current_tile();
     editor_tool_set_type(tool);
     if (window_is(WINDOW_EDITOR_BUILD_MENU)) {
         window_editor_map_show();

--- a/src/widget/sidebar_editor.c
+++ b/src/widget/sidebar_editor.c
@@ -182,9 +182,9 @@ void widget_sidebar_editor_handle_mouse_build_menu(const mouse *m)
     image_buttons_handle_mouse(m, get_x_offset(), 24, buttons_build, 17, 0);
 }
 
-void widget_sidebar_editor_handle_mouse_attributes(const mouse *m)
+int widget_sidebar_editor_handle_mouse_attributes(const mouse *m)
 {
-    image_buttons_handle_mouse(m, get_x_offset(), 24, buttons_build, 2, 0);
+    return image_buttons_handle_mouse(m, get_x_offset(), 24, buttons_build, 2, 0);
 }
 
 static void button_attributes(int show, int param2)

--- a/src/widget/sidebar_editor.h
+++ b/src/widget/sidebar_editor.h
@@ -8,7 +8,7 @@ void widget_sidebar_editor_draw_background(void);
 void widget_sidebar_editor_draw_foreground(void);
 
 int widget_sidebar_editor_handle_mouse(const mouse *m);
-void widget_sidebar_editor_handle_mouse_attributes(const mouse *m);
+int widget_sidebar_editor_handle_mouse_attributes(const mouse *m);
 void widget_sidebar_editor_handle_mouse_build_menu(const mouse *m);
 
 #endif // WIDGET_SIDEBAR_EDITOR_H

--- a/src/window/advisor/entertainment.c
+++ b/src/window/advisor/entertainment.c
@@ -161,9 +161,9 @@ static void draw_foreground(void)
     }
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
-    generic_buttons_handle_mouse(m, 0, 0, hold_festival_button, 1, &focus_button_id);
+    return generic_buttons_handle_mouse(m, 0, 0, hold_festival_button, 1, &focus_button_id);
 }
 
 static void button_hold_festival(int param1, int param2)

--- a/src/window/advisor/financial.c
+++ b/src/window/advisor/financial.c
@@ -103,9 +103,10 @@ static void draw_foreground(void)
     arrow_buttons_draw(0, 0, arrow_buttons_taxes, 2);
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
     arrow_button_focus = arrow_buttons_handle_mouse(m, 0, 0, arrow_buttons_taxes, 2);
+    return arrow_button_focus;
 }
 
 static void button_change_taxes(int is_down, int param2)

--- a/src/window/advisor/imperial.c
+++ b/src/window/advisor/imperial.c
@@ -200,9 +200,9 @@ static void draw_foreground(void)
     }
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
-    generic_buttons_handle_mouse(m, 0, 0, imperial_buttons, 8, &focus_button_id);
+    return generic_buttons_handle_mouse(m, 0, 0, imperial_buttons, 8, &focus_button_id);
 }
 
 static void button_donate_to_city(int param1, int param2)

--- a/src/window/advisor/labor.c
+++ b/src/window/advisor/labor.c
@@ -97,11 +97,13 @@ static void draw_foreground(void)
     }
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
-    if (!generic_buttons_handle_mouse(m, 0, 0, category_buttons, 9, &focus_button_id)) {
-        arrow_button_focus = arrow_buttons_handle_mouse(m, 0, 0, wage_buttons, 2);
+    if (generic_buttons_handle_mouse(m, 0, 0, category_buttons, 9, &focus_button_id)) {
+        return 1;
     }
+    arrow_button_focus = arrow_buttons_handle_mouse(m, 0, 0, wage_buttons, 2);
+    return arrow_button_focus;
 }
 
 static void arrow_button_wages(int is_down, int param2)

--- a/src/window/advisor/military.c
+++ b/src/window/advisor/military.c
@@ -159,9 +159,9 @@ static void draw_foreground(void)
     }
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
-    generic_buttons_handle_mouse(m, 0, 0, fort_buttons, 3 * num_legions, &focus_button_id);
+    return generic_buttons_handle_mouse(m, 0, 0, fort_buttons, 3 * num_legions, &focus_button_id);
 }
 
 static void button_go_to_legion(int legion_id, int param2)

--- a/src/window/advisor/population.c
+++ b/src/window/advisor/population.c
@@ -426,9 +426,9 @@ static void draw_foreground(void)
     }
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
-    generic_buttons_handle_mouse(m, 0, 0, graph_buttons, 2, &focus_button_id);
+    return generic_buttons_handle_mouse(m, 0, 0, graph_buttons, 2, &focus_button_id);
 }
 
 static void button_graph(int param1, int param2)

--- a/src/window/advisor/ratings.c
+++ b/src/window/advisor/ratings.c
@@ -155,9 +155,9 @@ static void draw_foreground(void)
     button_border_draw(440, 286, 110, 66, focus_button_id == SELECTED_RATING_FAVOR);
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
-    generic_buttons_handle_mouse(m, 0, 0, rating_buttons, 4, &focus_button_id);
+    return generic_buttons_handle_mouse(m, 0, 0, rating_buttons, 4, &focus_button_id);
 }
 
 static void button_rating(int rating, int param2)

--- a/src/window/advisor/trade.c
+++ b/src/window/advisor/trade.c
@@ -95,10 +95,10 @@ static void draw_foreground(void)
     lang_text_draw_centered(54, 30, 100, 402, 200, FONT_NORMAL_BLACK);
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_mouse(const mouse *m)
 {
     int num_resources = city_resource_get_available()->size;
-    generic_buttons_handle_mouse(m, 0, 0, resource_buttons, num_resources + 2, &focus_button_id);
+    return generic_buttons_handle_mouse(m, 0, 0, resource_buttons, num_resources + 2, &focus_button_id);
 }
 
 static void button_prices(int param1, int param2)

--- a/src/window/advisors.c
+++ b/src/window/advisors.c
@@ -170,13 +170,12 @@ static void handle_mouse(const mouse *m)
         focus_button_id = -1;
         return;
     }
-    if (m->right.went_up) {
-        window_city_show();
+    if (current_advisor_window->handle_mouse && current_advisor_window->handle_mouse(m_dialog)) {
         return;
     }
-
-    if (current_advisor_window->handle_mouse) {
-        current_advisor_window->handle_mouse(m_dialog);
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        window_city_show();
+        return;
     }
 }
 

--- a/src/window/advisors.h
+++ b/src/window/advisors.h
@@ -10,7 +10,7 @@ typedef struct {
      */
     int (*draw_background)(void);
     void (*draw_foreground)(void);
-    void (*handle_mouse)(const mouse *m);
+    int (*handle_mouse)(const mouse *m);
     int (*get_tooltip_text)(void);
 } advisor_window_type;
 

--- a/src/window/building/distribution.c
+++ b/src/window/building/distribution.c
@@ -215,9 +215,9 @@ void window_building_draw_granary_foreground(building_info_context *c)
         16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
 }
 
-void window_building_handle_mouse_granary(const mouse *m, building_info_context *c)
+int window_building_handle_mouse_granary(const mouse *m, building_info_context *c)
 {
-    generic_buttons_handle_mouse(
+    return generic_buttons_handle_mouse(
         m, c->x_offset + 80, c->y_offset + 16 * c->height_blocks - 34,
         go_to_orders_button, 1, &data.focus_button_id);
 }
@@ -278,7 +278,7 @@ void window_building_draw_granary_orders_foreground(building_info_context *c)
     }
 }
 
-void window_building_handle_mouse_granary_orders(const mouse *m, building_info_context *c)
+int window_building_handle_mouse_granary_orders(const mouse *m, building_info_context *c)
 {
     int y_offset = window_building_get_vertical_offset(c, 28);
 
@@ -286,9 +286,9 @@ void window_building_handle_mouse_granary_orders(const mouse *m, building_info_c
     if (generic_buttons_handle_mouse(m, c->x_offset + 180, y_offset + 46,
         orders_resource_buttons, city_resource_get_available_foods()->size,
         &data.resource_focus_button_id)) {
-        return;
+        return 1;
     }
-    generic_buttons_handle_mouse(m, c->x_offset + 80, y_offset + 404, granary_order_buttons, 2, &data.orders_focus_button_id);
+    return generic_buttons_handle_mouse(m, c->x_offset + 80, y_offset + 404, granary_order_buttons, 2, &data.orders_focus_button_id);
 }
 
 void window_building_get_tooltip_granary_orders(int *group_id, int *text_id)
@@ -362,9 +362,9 @@ void window_building_draw_warehouse_foreground(building_info_context *c)
         16 * (c->width_blocks - 10), FONT_NORMAL_BLACK);
 }
 
-void window_building_handle_mouse_warehouse(const mouse *m, building_info_context *c)
+int window_building_handle_mouse_warehouse(const mouse *m, building_info_context *c)
 {
-    generic_buttons_handle_mouse(m, c->x_offset + 80, c->y_offset + 16 * c->height_blocks - 34,
+    return generic_buttons_handle_mouse(m, c->x_offset + 80, c->y_offset + 16 * c->height_blocks - 34,
         go_to_orders_button, 1, &data.focus_button_id);
 }
 
@@ -420,7 +420,7 @@ void window_building_draw_warehouse_orders_foreground(building_info_context *c)
     }
 }
 
-void window_building_handle_mouse_warehouse_orders(const mouse *m, building_info_context *c)
+int window_building_handle_mouse_warehouse_orders(const mouse *m, building_info_context *c)
 {
     int y_offset = window_building_get_vertical_offset(c, 28);
 
@@ -428,9 +428,9 @@ void window_building_handle_mouse_warehouse_orders(const mouse *m, building_info
     if (generic_buttons_handle_mouse(m, c->x_offset + 180, y_offset + 46,
         orders_resource_buttons, city_resource_get_available()->size,
         &data.resource_focus_button_id)) {
-        return;
+        return 1;
     }
-    generic_buttons_handle_mouse(m, c->x_offset + 80, y_offset + 404,
+    return generic_buttons_handle_mouse(m, c->x_offset + 80, y_offset + 404,
         warehouse_order_buttons, 3, &data.orders_focus_button_id);
 }
 

--- a/src/window/building/distribution.h
+++ b/src/window/building/distribution.h
@@ -13,8 +13,8 @@ void window_building_draw_granary_foreground(building_info_context *c);
 void window_building_draw_granary_orders(building_info_context *c);
 void window_building_draw_granary_orders_foreground(building_info_context *c);
 
-void window_building_handle_mouse_granary(const mouse *m, building_info_context *c);
-void window_building_handle_mouse_granary_orders(const mouse *m, building_info_context *c);
+int window_building_handle_mouse_granary(const mouse *m, building_info_context *c);
+int window_building_handle_mouse_granary_orders(const mouse *m, building_info_context *c);
 
 void window_building_get_tooltip_granary_orders(int *group_id, int *text_id);
 
@@ -23,8 +23,8 @@ void window_building_draw_warehouse_foreground(building_info_context *c);
 void window_building_draw_warehouse_orders(building_info_context *c);
 void window_building_draw_warehouse_orders_foreground(building_info_context *c);
 
-void window_building_handle_mouse_warehouse(const mouse *m, building_info_context *c);
-void window_building_handle_mouse_warehouse_orders(const mouse *m, building_info_context *c);
+int window_building_handle_mouse_warehouse(const mouse *m, building_info_context *c);
+int window_building_handle_mouse_warehouse_orders(const mouse *m, building_info_context *c);
 
 void window_building_get_tooltip_warehouse_orders(int *group_id, int *text_id);
 

--- a/src/window/building/figures.c
+++ b/src/window/building/figures.c
@@ -379,11 +379,12 @@ void window_building_prepare_figure_list(building_info_context *c)
     }
 }
 
-void window_building_handle_mouse_figure_list(const mouse *m, building_info_context *c)
+int window_building_handle_mouse_figure_list(const mouse *m, building_info_context *c)
 {
     data.context_for_callback = c;
-    generic_buttons_handle_mouse(m, c->x_offset, c->y_offset, figure_buttons, c->figure.count, &data.focus_button_id);
+    int handled = generic_buttons_handle_mouse(m, c->x_offset, c->y_offset, figure_buttons, c->figure.count, &data.focus_button_id);
     data.context_for_callback = 0;
+    return handled;
 }
 
 static void select_figure(int index, int param2)

--- a/src/window/building/figures.h
+++ b/src/window/building/figures.h
@@ -8,7 +8,7 @@ void window_building_prepare_figure_list(building_info_context *c);
 
 void window_building_draw_figure_list(building_info_context *c);
 
-void window_building_handle_mouse_figure_list(const mouse *m, building_info_context *c);
+int window_building_handle_mouse_figure_list(const mouse *m, building_info_context *c);
 
 void window_building_play_figure_phrase(building_info_context *c);
 

--- a/src/window/building/military.c
+++ b/src/window/building/military.c
@@ -360,7 +360,7 @@ void window_building_draw_legion_info_foreground(building_info_context *c)
     }
 }
 
-void window_building_handle_mouse_legion_info(const mouse *m, building_info_context *c)
+int window_building_handle_mouse_legion_info(const mouse *m, building_info_context *c)
 {
     data.context_for_callback = c;
     int handled = generic_buttons_handle_mouse(m, c->x_offset, c->y_offset, layout_buttons, 5, &data.focus_button_id);
@@ -370,10 +370,11 @@ void window_building_handle_mouse_legion_info(const mouse *m, building_info_cont
         }
     }
     if (!handled) {
-        generic_buttons_handle_mouse(m, c->x_offset + 16 * (c->width_blocks - 18) / 2,
+        handled = generic_buttons_handle_mouse(m, c->x_offset + 16 * (c->width_blocks - 18) / 2,
             c->y_offset + 16 * c->height_blocks - 48, return_button, 1, &data.return_button_id);
     }
     data.context_for_callback = 0;
+    return handled;
 }
 
 int window_building_get_legion_info_tooltip_text(building_info_context *c)

--- a/src/window/building/military.h
+++ b/src/window/building/military.h
@@ -15,7 +15,7 @@ void window_building_draw_fort(building_info_context *c);
 
 void window_building_draw_legion_info(building_info_context *c);
 void window_building_draw_legion_info_foreground(building_info_context *c);
-void window_building_handle_mouse_legion_info(const mouse *m, building_info_context *c);
+int window_building_handle_mouse_legion_info(const mouse *m, building_info_context *c);
 int window_building_get_legion_info_tooltip_text(building_info_context *c);
 
 #endif // WINDOW_BUILDING_MILITARY_H

--- a/src/window/building_info.c
+++ b/src/window/building_info.c
@@ -521,41 +521,23 @@ static void draw_foreground(void)
     }
 }
 
-static void handle_mouse(const mouse *m)
+static int handle_specific_building_info_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
-        window_city_show();
-        return;
-    }
-    // general buttons
-    if (context.storage_show_special_orders) {
-        int y_offset = window_building_get_vertical_offset(&context, 28);
-        image_buttons_handle_mouse(m, context.x_offset, y_offset + 400, image_buttons_help_close, 2, &focus_image_button_id);
-    } else {
-        image_buttons_handle_mouse(
-            m, context.x_offset, context.y_offset + 16 * context.height_blocks - 40,
-            image_buttons_help_close, 2, &focus_image_button_id);
-    }
-    if (context.can_go_to_advisor) {
-        image_buttons_handle_mouse(
-            m, context.x_offset, context.y_offset + 16 * context.height_blocks - 40,
-            image_buttons_advisor, 1, 0);
-    }
     // building-specific buttons
     if (context.type == BUILDING_INFO_NONE) {
-        return;
+        return 0;
     }
     if (context.type == BUILDING_INFO_LEGION) {
-        window_building_handle_mouse_legion_info(m, &context);
+        return window_building_handle_mouse_legion_info(m, &context);
     } else if (context.figure.drawn) {
-        window_building_handle_mouse_figure_list(m, &context);
+        return window_building_handle_mouse_figure_list(m, &context);
     } else if (context.type == BUILDING_INFO_BUILDING) {
         int btype = building_get(context.building_id)->type;
         if (btype == BUILDING_GRANARY) {
             if (context.storage_show_special_orders) {
-                window_building_handle_mouse_granary_orders(m, &context);
+                return window_building_handle_mouse_granary_orders(m, &context);
             } else {
-                window_building_handle_mouse_granary(m, &context);
+                return window_building_handle_mouse_granary(m, &context);
             }
         } else if (btype == BUILDING_WAREHOUSE) {
             if (context.storage_show_special_orders) {
@@ -564,6 +546,32 @@ static void handle_mouse(const mouse *m)
                 window_building_handle_mouse_warehouse(m, &context);
             }
         }
+    }
+    return 0;
+}
+
+static void handle_mouse(const mouse *m)
+{
+    int handled = 0;
+    // general buttons
+    if (context.storage_show_special_orders) {
+        int y_offset = window_building_get_vertical_offset(&context, 28);
+        handled = image_buttons_handle_mouse(m, context.x_offset, y_offset + 400, image_buttons_help_close, 2, &focus_image_button_id);
+    } else {
+        handled = image_buttons_handle_mouse(
+                      m, context.x_offset, context.y_offset + 16 * context.height_blocks - 40,
+                      image_buttons_help_close, 2, &focus_image_button_id);
+    }
+    if (context.can_go_to_advisor) {
+        handled = image_buttons_handle_mouse(
+                      m, context.x_offset, context.y_offset + 16 * context.height_blocks - 40,
+                      image_buttons_advisor, 1, 0);
+    }
+    if (!handled) {
+        handled = handle_specific_building_info_mouse(m);
+    }
+    if (!handled && (m->right.went_up || (m->is_touch && m->left.double_click))) {
+        window_city_show();
     }
 }
 

--- a/src/window/cck_selection.c
+++ b/src/window/cck_selection.c
@@ -241,10 +241,6 @@ static void handle_mouse(const mouse *m)
     if (handle_scrollbar(m)) {
         return;
     }
-    if (m->right.went_up) {
-        window_go_back();
-        return;
-    }
     const mouse *m_dialog = mouse_in_dialog(m);
     if (image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons, 3, 0)) {
         return;
@@ -254,6 +250,10 @@ static void handle_mouse(const mouse *m)
     }
     if (keyboard_input_is_accepted()) {
         button_start_scenario(0, 0);
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        window_go_back();
     }
 }
 

--- a/src/window/city.c
+++ b/src/window/city.c
@@ -63,6 +63,19 @@ static void draw_paused_and_time_left(void)
     }
 }
 
+static void draw_cancel_construction(void)
+{
+    if (!mouse_get()->is_touch || !building_construction_type()) {
+        return;
+    }
+    uint8_t cancel_button_text[] = { 'X', 0 };
+    int x, y, width, height;
+    city_view_get_viewport(&x, &y, &width, &height);
+    width -= 4 * 16;
+    outer_panel_draw(width, 40, 3, 3);
+    text_draw_centered(cancel_button_text, width, 58, 3 * 16, FONT_NORMAL_BLACK, 0);
+}
+
 static void draw_foreground(void)
 {
     widget_top_menu_draw(0);
@@ -70,6 +83,7 @@ static void draw_foreground(void)
     widget_sidebar_draw_foreground();
     if (window_is(WINDOW_CITY) || window_is(WINDOW_CITY_MILITARY)) {
         draw_paused_and_time_left();
+        draw_cancel_construction();
     }
     widget_city_draw_construction_cost_and_size();
     if (window_is(WINDOW_CITY)) {

--- a/src/window/city.c
+++ b/src/window/city.c
@@ -6,6 +6,7 @@
 #include "city/view.h"
 #include "game/state.h"
 #include "game/time.h"
+#include "graphics/image.h"
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 #include "graphics/text.h"
@@ -68,12 +69,11 @@ static void draw_cancel_construction(void)
     if (!mouse_get()->is_touch || !building_construction_type()) {
         return;
     }
-    uint8_t cancel_button_text[] = { 'X', 0 };
     int x, y, width, height;
     city_view_get_viewport(&x, &y, &width, &height);
     width -= 4 * 16;
-    outer_panel_draw(width, 40, 3, 3);
-    text_draw_centered(cancel_button_text, width, 58, 3 * 16, FONT_NORMAL_BLACK, 0);
+    inner_panel_draw(width - 4, 40, 3, 2);
+    image_draw(image_group(GROUP_OK_CANCEL_SCROLL_BUTTONS) + 4, width, 44);
 }
 
 static void draw_foreground(void)

--- a/src/window/config.c
+++ b/src/window/config.c
@@ -165,7 +165,7 @@ static void handle_mouse(const mouse *m)
     handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, checkbox_buttons, NUM_CHECKBOXES, &data.focus_button);
     handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, bottom_buttons, NUM_BOTTOM_BUTTONS, &data.bottom_focus_button);
     handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, &language_button, 1, &data.language_focus_button);
-    if (!handled && (m->right.went_up || (m->is_touch && m->left.double_click))) {
+    if (!handled && m->right.went_up) {
         window_main_menu_show(0);
     }
 }

--- a/src/window/config.c
+++ b/src/window/config.c
@@ -161,9 +161,13 @@ static void draw_foreground(void)
 static void handle_mouse(const mouse *m)
 {
     const mouse *m_dialog = mouse_in_dialog(m);
-    generic_buttons_handle_mouse(m_dialog, 0, 0, checkbox_buttons, NUM_CHECKBOXES, &data.focus_button);
-    generic_buttons_handle_mouse(m_dialog, 0, 0, bottom_buttons, NUM_BOTTOM_BUTTONS, &data.bottom_focus_button);
-    generic_buttons_handle_mouse(m_dialog, 0, 0, &language_button, 1, &data.language_focus_button);
+    int handled = 0;
+    handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, checkbox_buttons, NUM_CHECKBOXES, &data.focus_button);
+    handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, bottom_buttons, NUM_BOTTOM_BUTTONS, &data.bottom_focus_button);
+    handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, &language_button, 1, &data.language_focus_button);
+    if (!handled && (m->right.went_up || (m->is_touch && m->left.double_click))) {
+        window_main_menu_show(0);
+    }
 }
 
 static void toggle_switch(int key, int param2)

--- a/src/window/difficulty_options.c
+++ b/src/window/difficulty_options.c
@@ -38,10 +38,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (arrow_buttons_handle_mouse(mouse_in_dialog(m), 288, 80, arrow_buttons, 4)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         data.close_callback();
-    } else {
-        arrow_buttons_handle_mouse(mouse_in_dialog(m), 288, 80, arrow_buttons, 4);
     }
 }
 

--- a/src/window/display_options.c
+++ b/src/window/display_options.c
@@ -57,10 +57,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 5, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         data.close_callback();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 5, &data.focus_button_id);
     }
 }
 

--- a/src/window/donate_to_city.c
+++ b/src/window/donate_to_city.c
@@ -84,13 +84,16 @@ static void draw_foreground(void)
 static void handle_mouse(const mouse *m)
 {
     focus_arrow_button_id = 0;
-    if (m->right.went_up) {
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 7, &focus_button_id)) {
+        return;
+    }
+    focus_arrow_button_id = arrow_buttons_handle_mouse(m_dialog, 0, 0, arrow_buttons, 2);
+    if (focus_arrow_button_id) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_advisors_show();
-    } else {
-        const mouse *m_dialog = mouse_in_dialog(m);
-        if (!generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 7, &focus_button_id)) {
-            focus_arrow_button_id = arrow_buttons_handle_mouse(m_dialog, 0, 0, arrow_buttons, 2);
-        }
     }
 }
 

--- a/src/window/editor/allowed_buildings.c
+++ b/src/window/editor/allowed_buildings.c
@@ -107,7 +107,7 @@ static void handle_mouse(const mouse *m)
     if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 47, &focus_button_id)) {
         return;
     }
-    if(m->right.went_up || (m->is_touch && m->left.double_click)) {
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
     }
 }

--- a/src/window/editor/allowed_buildings.c
+++ b/src/window/editor/allowed_buildings.c
@@ -104,10 +104,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 47, &focus_button_id)) {
+        return;
+    }
+    if(m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 47, &focus_button_id);
     }
 }
 

--- a/src/window/editor/attributes.c
+++ b/src/window/editor/attributes.c
@@ -170,19 +170,16 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (input_box_handle_mouse(m_dialog, &scenario_description_input) ||
+        generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 10, &data.focus_button_id) ||
+        arrow_buttons_handle_mouse(m_dialog, 0, 0, image_arrows, 2) ||
+        widget_sidebar_editor_handle_mouse_attributes(m)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         stop(0);
         window_editor_map_show();
-    } else {
-        const mouse *m_dialog = mouse_in_dialog(m);
-        if (input_box_handle_mouse(m_dialog, &scenario_description_input)) {
-            return;
-        }
-        if (!generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 10, &data.focus_button_id)) {
-            if (!arrow_buttons_handle_mouse(m_dialog, 0, 0, image_arrows, 2)) {
-                widget_sidebar_editor_handle_mouse_attributes(m);
-            }
-        }
     }
 }
 

--- a/src/window/editor/build_menu.c
+++ b/src/window/editor/build_menu.c
@@ -6,6 +6,7 @@
 #include "graphics/lang_text.h"
 #include "graphics/panel.h"
 #include "graphics/window.h"
+#include "widget/map_editor.h"
 #include "widget/sidebar_editor.h"
 #include "window/editor/map.h"
 
@@ -117,6 +118,8 @@ static void handle_mouse(const mouse *m)
 
 static void button_menu_item(int index, int param2)
 {
+    widget_map_editor_clear_current_tile();
+
     switch (data.selected_submenu) {
         case MENU_BRUSH_SIZE:
             editor_tool_set_brush_size(index + 1);

--- a/src/window/editor/demand_changes.c
+++ b/src/window/editor/demand_changes.c
@@ -86,10 +86,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id);
     }
 }
 

--- a/src/window/editor/edit_demand_change.c
+++ b/src/window/editor/edit_demand_change.c
@@ -118,10 +118,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 6, &data.focus_button_id)) {
+        return;
+    }
+    if(m->right.went_up || (m->is_touch && m->left.double_click)) {
         button_save(0, 0);
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 6, &data.focus_button_id);
     }
 }
 

--- a/src/window/editor/edit_demand_change.c
+++ b/src/window/editor/edit_demand_change.c
@@ -121,7 +121,7 @@ static void handle_mouse(const mouse *m)
     if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 6, &data.focus_button_id)) {
         return;
     }
-    if(m->right.went_up || (m->is_touch && m->left.double_click)) {
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         button_save(0, 0);
     }
 }

--- a/src/window/editor/edit_invasion.c
+++ b/src/window/editor/edit_invasion.c
@@ -88,10 +88,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 7, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         button_save(0, 0);
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 7, &data.focus_button_id);
     }
 }
 

--- a/src/window/editor/edit_price_change.c
+++ b/src/window/editor/edit_price_change.c
@@ -79,10 +79,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 6, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         button_save(0, 0);
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 6, &data.focus_button_id);
     }
 }
 

--- a/src/window/editor/edit_request.c
+++ b/src/window/editor/edit_request.c
@@ -88,10 +88,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 7, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         button_save(0, 0);
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 7, &data.focus_button_id);
     }
 }
 

--- a/src/window/editor/empire.c
+++ b/src/window/editor/empire.c
@@ -333,14 +333,13 @@ static void handle_mouse(const mouse *m)
     if (!arrow_buttons_handle_mouse(m, data.x_min + 20, data.y_max - 100, arrow_buttons_empire, 2)) {
         if (!generic_buttons_handle_mouse(m, data.x_min + 20, data.y_max - 100, generic_button_ok, 1, &data.focus_button_id)) {
             determine_selected_object(m);
-            if (m->right.went_up) {
-                window_editor_map_show();
-            }
             int selected_object = empire_selected_object();
             if (selected_object) {
                 if (empire_object_get(selected_object - 1)->type == EMPIRE_OBJECT_CITY) {
                     data.selected_city = empire_city_get_for_object(selected_object - 1);
                 }
+            } else if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+                window_editor_map_show();
             }
         }
     }

--- a/src/window/editor/empire.c
+++ b/src/window/editor/empire.c
@@ -319,7 +319,7 @@ static void handle_mouse(const mouse *m)
         if (t->has_ended) {
             data.is_scrolling = 0;
             data.finished_scroll = !touch_was_click(t);
-            scroll_end_touch_drag();
+            scroll_end_touch_drag(1);
         }
     }
     pixel_offset position;
@@ -334,8 +334,7 @@ static void handle_mouse(const mouse *m)
         if (!generic_buttons_handle_mouse(m, data.x_min + 20, data.y_max - 100, generic_button_ok, 1, &data.focus_button_id)) {
             determine_selected_object(m);
             if (m->right.went_up) {
-                empire_clear_selected_object();
-                window_invalidate();
+                window_editor_map_show();
             }
             int selected_object = empire_selected_object();
             if (selected_object) {

--- a/src/window/editor/invasions.c
+++ b/src/window/editor/invasions.c
@@ -80,10 +80,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id);
     }
 }
 

--- a/src/window/editor/invasions.c
+++ b/src/window/editor/invasions.c
@@ -80,7 +80,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/map.c
+++ b/src/window/editor/map.c
@@ -1,6 +1,8 @@
 #include "map.h"
 
+#include "city/view.h"
 #include "editor/editor.h"
+#include "editor/tool.h"
 #include "game/game.h"
 #include "graphics/generic_button.h"
 #include "graphics/graphics.h"
@@ -22,10 +24,25 @@ static void draw_background(void)
     widget_top_menu_editor_draw();
 }
 
+static void draw_cancel_construction(void)
+{
+    if (!mouse_get()->is_touch || !editor_tool_is_active()) {
+        return;
+    }
+    int x, y, width, height;
+    city_view_get_viewport(&x, &y, &width, &height);
+    width -= 4 * 16;
+    inner_panel_draw(width - 4, 40, 3, 2);
+    image_draw(image_group(GROUP_OK_CANCEL_SCROLL_BUTTONS) + 4, width, 44);
+}
+
 static void draw_foreground(void)
 {
     widget_sidebar_editor_draw_foreground();
     widget_map_editor_draw();
+    if (window_is(WINDOW_EDITOR_MAP)) {
+        draw_cancel_construction();
+    }
 }
 
 static void handle_mouse(const mouse *m)

--- a/src/window/editor/price_changes.c
+++ b/src/window/editor/price_changes.c
@@ -86,10 +86,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id);
     }
 }
 

--- a/src/window/editor/price_changes.c
+++ b/src/window/editor/price_changes.c
@@ -86,7 +86,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/requests.c
+++ b/src/window/editor/requests.c
@@ -85,7 +85,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/requests.c
+++ b/src/window/editor/requests.c
@@ -85,10 +85,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 20, &focus_button_id);
     }
 }
 

--- a/src/window/editor/special_events.c
+++ b/src/window/editor/special_events.c
@@ -138,10 +138,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 13, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 13, &focus_button_id);
     }
 }
 

--- a/src/window/editor/special_events.c
+++ b/src/window/editor/special_events.c
@@ -138,7 +138,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 13, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 13, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/start_year.c
+++ b/src/window/editor/start_year.c
@@ -50,7 +50,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 2, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 2, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/start_year.c
+++ b/src/window/editor/start_year.c
@@ -50,10 +50,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 2, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_starting_conditions_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 2, &focus_button_id);
     }
 }
 

--- a/src/window/editor/starting_conditions.c
+++ b/src/window/editor/starting_conditions.c
@@ -97,10 +97,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 9, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 9, &focus_button_id);
     }
 }
 

--- a/src/window/editor/starting_conditions.c
+++ b/src/window/editor/starting_conditions.c
@@ -97,7 +97,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 9, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 9, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/win_criteria.c
+++ b/src/window/editor/win_criteria.c
@@ -123,7 +123,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 15, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 15, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/editor/win_criteria.c
+++ b/src/window/editor/win_criteria.c
@@ -123,10 +123,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 15, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_editor_attributes_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 15, &focus_button_id);
     }
 }
 

--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -479,9 +479,6 @@ static void handle_mouse(const mouse *m)
         return;
     }
     determine_selected_object(m);
-    if (m->right.went_up) {
-        window_city_show();
-    }
     int selected_object = empire_selected_object();
     if (selected_object) {
         if (empire_object_get(selected_object -1)->type == EMPIRE_OBJECT_CITY) {
@@ -492,6 +489,10 @@ static void handle_mouse(const mouse *m)
                     m, (data.x_min + data.x_max - 500) / 2, data.y_max - 105,
                         generic_button_open_trade, 1, &data.selected_button);
             }
+        }
+    } else {
+        if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+            window_city_show();
         }
     }
 }

--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -451,7 +451,7 @@ static void handle_mouse(const mouse *m)
         if (t->has_ended) {
             data.is_scrolling = 0;
             data.finished_scroll = !touch_was_click(t);
-            scroll_end_touch_drag();
+            scroll_end_touch_drag(1);
         }
     }
     pixel_offset position;
@@ -480,8 +480,7 @@ static void handle_mouse(const mouse *m)
     }
     determine_selected_object(m);
     if (m->right.went_up) {
-        empire_clear_selected_object();
-        window_invalidate();
+        window_city_show();
     }
     int selected_object = empire_selected_object();
     if (selected_object) {

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -190,19 +190,16 @@ static void handle_mouse(const mouse *m)
         return;
     }
 
-    if (m->right.went_up) {
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (input_box_handle_mouse(m_dialog, &file_name_input) ||
+        generic_buttons_handle_mouse(m_dialog, 0, 0, file_buttons, 12, &data.focus_button_id) ||
+        image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons, 4, 0) ||
+        handle_scrollbar(m)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         keyboard_stop_capture();
         window_go_back();
-        return;
-    }
-    const mouse *m_dialog = mouse_in_dialog(m);
-    if (input_box_handle_mouse(m_dialog, &file_name_input)) {
-        return;
-    }
-    if (!generic_buttons_handle_mouse(m_dialog, 0, 0, file_buttons, 12, &data.focus_button_id)) {
-        if (!image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons, 4, 0)) {
-            handle_scrollbar(m);
-        }
     }
 }
 

--- a/src/window/gift_to_emperor.c
+++ b/src/window/gift_to_emperor.c
@@ -88,10 +88,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 5, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_advisors_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 5, &focus_button_id);
     }
 }
 

--- a/src/window/gift_to_emperor.c
+++ b/src/window/gift_to_emperor.c
@@ -88,7 +88,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 5, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 5, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/hold_festival.c
+++ b/src/window/hold_festival.c
@@ -104,16 +104,15 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
-        window_advisors_show();
-        return;
-    }
-
     const mouse *m_dialog = mouse_in_dialog(m);
-    image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons_bottom, 4, &focus_image_button_id);
-    generic_buttons_handle_mouse(m_dialog, 0, 0, buttons_gods_size, 8, &focus_button_id);
+    int handled = 0;
+    handled |= image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons_bottom, 4, &focus_image_button_id);
+    handled |= generic_buttons_handle_mouse(m_dialog, 0, 0, buttons_gods_size, 8, &focus_button_id);
     if (focus_image_button_id) {
         focus_button_id = 0;
+    }
+    if (!handled && (m->right.went_up || (m->is_touch && m->left.double_click))) {
+        window_advisors_show();
     }
 }
 

--- a/src/window/labor_priority.c
+++ b/src/window/labor_priority.c
@@ -96,10 +96,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, priority_buttons, 1 + data.max_items, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_go_back();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, priority_buttons, 1 + data.max_items, &data.focus_button_id);
     }
 }
 

--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -16,6 +16,7 @@
 #include "graphics/text.h"
 #include "graphics/video.h"
 #include "graphics/window.h"
+#include "input/scroll.h"
 #include "scenario/property.h"
 #include "scenario/request.h"
 #include "window/advisors.h"
@@ -108,6 +109,7 @@ static void set_city_message(int year, int month,
 
 static void init(int text_id, void (*background_callback)(void))
 {
+    scroll_end_touch_drag(0);
     for (int i = 0; i < MAX_HISTORY; i++) {
         data.history[i].text_id = 0;
         data.history[i].scroll_position = 0;
@@ -477,9 +479,6 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
-        button_close(0, 0);
-    }
     data.focus_button_id = 0;
     const mouse *m_dialog = mouse_in_dialog(m);
     const lang_message *msg = lang_get_message(data.text_id);
@@ -491,7 +490,12 @@ static void handle_mouse(const mouse *m)
             return;
         }
         if (is_problem_message(msg)) {
-            image_buttons_handle_mouse(m_dialog, data.x + 48, data.y + 407, &image_button_go_to_problem, 1, &data.focus_button_id);
+            if (image_buttons_handle_mouse(m_dialog, data.x + 48, data.y + 407, &image_button_go_to_problem, 1, &data.focus_button_id)) {
+                return;
+            }
+        }
+        if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+            button_close(0, 0);
         }
         return;
     }
@@ -529,6 +533,10 @@ static void handle_mouse(const mouse *m)
         data.text_id = text_id;
         rich_text_reset(0);
         window_invalidate();
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        button_close(0, 0);
     }
 }
 

--- a/src/window/message_list.c
+++ b/src/window/message_list.c
@@ -158,10 +158,10 @@ static void draw_foreground(void)
     graphics_reset_dialog();
 }
 
-static void handle_mouse_scrollbar(const mouse *m)
+static int handle_mouse_scrollbar(const mouse *m)
 {
     if (!city_message_can_scroll() || !m->left.is_down) {
-        return;
+        return 0;
     }
     int scrollbar_x = data.x_text + 16 * data.text_width_blocks + 1;
     int scrollbar_y = data.y_text + 26;
@@ -180,7 +180,9 @@ static void handle_mouse_scrollbar(const mouse *m)
             data.scroll_position_drag = 0;
         }
         window_invalidate();
+        return 1;
     }
+    return 0;
 }
 
 static void handle_mouse(const mouse *m)
@@ -222,8 +224,10 @@ static void handle_mouse(const mouse *m)
         }
         return;
     }
-    handle_mouse_scrollbar(m_dialog);
-    if (m_dialog->right.went_up) {
+    if (handle_mouse_scrollbar(m_dialog)) {
+        return;
+    }
+    if (m_dialog->right.went_up || (m->is_touch && m->left.double_click)) {
         button_close(0, 0);
     }
 }

--- a/src/window/new_career.c
+++ b/src/window/new_career.c
@@ -64,12 +64,6 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
-        keyboard_stop_capture();
-        window_go_back();
-        return;
-    }
-
     const mouse *m_dialog = mouse_in_dialog(m);
     if (input_box_handle_mouse(m_dialog, &player_name_input) ||
         image_buttons_handle_mouse(m_dialog, 159, 249, image_buttons, 2, 0)) {
@@ -77,6 +71,11 @@ static void handle_mouse(const mouse *m)
     }
     if (keyboard_input_is_accepted()) {
         start_mission(0, 0);
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        keyboard_stop_capture();
+        window_go_back();
     }
 }
 

--- a/src/window/numeric_input.c
+++ b/src/window/numeric_input.c
@@ -93,7 +93,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(m, data.x, data.y, buttons, 12, &data.focus_button_id)) {
+    if (generic_buttons_handle_mouse(m, data.x, data.y, buttons, 12, &data.focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/numeric_input.c
+++ b/src/window/numeric_input.c
@@ -93,10 +93,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(m, data.x, data.y, buttons, 12, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_go_back();
-    } else {
-        generic_buttons_handle_mouse(m, data.x, data.y, buttons, 12, &data.focus_button_id);
     }
 }
 

--- a/src/window/plain_message_dialog.c
+++ b/src/window/plain_message_dialog.c
@@ -48,7 +48,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(image_buttons_handle_mouse(mouse_in_dialog(m), 80, 80, buttons, 1, 0)) {
+    if (image_buttons_handle_mouse(mouse_in_dialog(m), 80, 80, buttons, 1, 0)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/plain_message_dialog.c
+++ b/src/window/plain_message_dialog.c
@@ -48,10 +48,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(image_buttons_handle_mouse(mouse_in_dialog(m), 80, 80, buttons, 1, 0)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_plain_message_dialog_accept();
-    } else {
-        image_buttons_handle_mouse(mouse_in_dialog(m), 80, 80, buttons, 1, 0);
     }
 }
 

--- a/src/window/popup_dialog.c
+++ b/src/window/popup_dialog.c
@@ -79,7 +79,7 @@ static void handle_mouse(const mouse *m)
 {
     if (data.has_buttons) {
         image_buttons_handle_mouse(mouse_in_dialog(m), 80, 80, buttons, 2, 0);
-    } else if (m->right.went_up) {
+    } else if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         data.close_func(0);
         window_go_back();
     }

--- a/src/window/resource_settings.c
+++ b/src/window/resource_settings.c
@@ -165,10 +165,6 @@ static void draw_foreground(void)
 static void handle_mouse(const mouse *m)
 {
     const mouse *m_dialog = mouse_in_dialog(m);
-    if (m->right.went_up) {
-        window_advisors_show();
-        return;
-    }
     if (image_buttons_handle_mouse(m_dialog, 0, 0, resource_image_buttons, 2, 0)) {
         return;
     }
@@ -176,7 +172,12 @@ static void handle_mouse(const mouse *m)
             arrow_buttons_handle_mouse(m_dialog, 0, 0, resource_arrow_buttons, 2)) {
         return;
     }
-    generic_buttons_handle_mouse(m_dialog, 0, 0, resource_generic_buttons, 3, &data.focus_button_id);
+    if (generic_buttons_handle_mouse(m_dialog, 0, 0, resource_generic_buttons, 3, &data.focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        window_advisors_show();
+    }
 }
 
 static void button_help(int param1, int param2)

--- a/src/window/select_list.c
+++ b/src/window/select_list.c
@@ -130,20 +130,24 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
-        window_go_back();
-    }
     if (data.num_items > MAX_ITEMS_PER_LIST) {
         int items_first = items_in_first_list();
-        if (!generic_buttons_handle_mouse(m, data.x, data.y, buttons_list1, items_first, &data.focus_button_id)) {
-            int second_id = 0;
-            generic_buttons_handle_mouse(m, data.x, data.y, buttons_list2, data.num_items - items_first, &second_id);
-            if (second_id > 0) {
-                data.focus_button_id = second_id + MAX_ITEMS_PER_LIST;
-            }
+        if (generic_buttons_handle_mouse(m, data.x, data.y, buttons_list1, items_first, &data.focus_button_id)) {
+            return;
+        }
+        int second_id = 0;
+        generic_buttons_handle_mouse(m, data.x, data.y, buttons_list2, data.num_items - items_first, &second_id);
+        if (second_id > 0) {
+            data.focus_button_id = second_id + MAX_ITEMS_PER_LIST;
+            return;
         }
     } else {
-        generic_buttons_handle_mouse(m, data.x, data.y, buttons_list1, data.num_items, &data.focus_button_id);
+        if (generic_buttons_handle_mouse(m, data.x, data.y, buttons_list1, data.num_items, &data.focus_button_id)) {
+            return;
+        }
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        window_go_back();
     }
 }
 

--- a/src/window/set_salary.c
+++ b/src/window/set_salary.c
@@ -82,11 +82,11 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 12, &focus_button_id)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_advisors_show();
-    } else {
-        generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0,
-            buttons, 12, &focus_button_id);
     }
 }
 

--- a/src/window/set_salary.c
+++ b/src/window/set_salary.c
@@ -82,7 +82,7 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if(generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 12, &focus_button_id)) {
+    if (generic_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, buttons, 12, &focus_button_id)) {
         return;
     }
     if (m->right.went_up || (m->is_touch && m->left.double_click)) {

--- a/src/window/sound_options.c
+++ b/src/window/sound_options.c
@@ -110,13 +110,13 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 6, &data.focus_button_id) ||
+        arrow_buttons_handle_mouse(m_dialog, 208, 60, arrow_buttons, 8)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         data.close_callback();
-    } else {
-        const mouse *m_dialog = mouse_in_dialog(m);
-        if (!generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 6, &data.focus_button_id)) {
-            arrow_buttons_handle_mouse(m_dialog, 208, 60, arrow_buttons, 8);
-        }
     }
 }
 

--- a/src/window/speed_options.c
+++ b/src/window/speed_options.c
@@ -70,13 +70,13 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 2, &data.focus_button_id) ||
+        arrow_buttons_handle_mouse(m_dialog, 160, 40, arrow_buttons, 4)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         data.close_callback();
-    } else {
-        const mouse *m_dialog = mouse_in_dialog(m);
-        if (!generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 2, &data.focus_button_id)) {
-            arrow_buttons_handle_mouse(m_dialog, 160, 40, arrow_buttons, 4);
-        }
     }
 }
 

--- a/src/window/trade_opened.c
+++ b/src/window/trade_opened.c
@@ -46,7 +46,12 @@ static void draw_foreground(void)
 
 static void handle_mouse(const mouse *m)
 {
-    image_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, image_buttons, 2, 0);
+    if (image_buttons_handle_mouse(mouse_in_dialog(m), 0, 0, image_buttons, 2, 0)) {
+        return;
+    }
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
+        window_empire_show();
+    }
 }
 
 static void button_advisor(int advisor, int param2)

--- a/src/window/trade_prices.c
+++ b/src/window/trade_prices.c
@@ -34,7 +34,7 @@ static void draw_background(void)
 
 static void handle_mouse(const mouse *m)
 {
-    if (m->right.went_up) {
+    if (m->right.went_up || (m->is_touch && m->left.double_click)) {
         window_advisors_show();
     }
 }

--- a/test/stub/input.c
+++ b/test/stub/input.c
@@ -9,3 +9,8 @@ int scroll_in_progress(void)
 {
     return 0;
 }
+
+int scroll_is_smooth(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Fix #269.

**Note:** Due to the fact that I implemented double-tap as a way to exit most menus, I had to change the exit code for nearly all the windows in the game. Hence the huge amount of changed files.

Here are some of the new features:

* Cancel build button. Only appears when touch is being used.
* Double tap to exit most windows
* Increased top menu options hitbox to make it easier to select the menu option
* Keep overlay submenu open on main button click. Works for both touch and mouse
* Single tap on city without any construction active to show building info
* Scrolling no longer stops the city when either smooth scrolling is active or touch is used to scroll
* Complete overhaul of construction using touch
* Support for touch on the map editor

**New way to construct using touch**

There are two types of construction: some can be click-dragged, others cannot (they are single buildings).
Examples of constructions that can be click-dragged: roads, houses, walls, reservoirs, clear land.

There are different (but somewhat similar) ways to build a simple and a click-draggable construction.

__For simple builings:__ tap anywhere on the map to show the ghost. Tap again on the same spot to confirm construction or somewhere else to move the ghost. If you press-drag, the building ghost will move with your finger.

__For click-draggable buildings:__ Press to set the starting position. You can then either drag the finger to extend the construction range, or immediately lift the finger and tap somewhere else to extend the construction range. To confirm the construction, tap at the end of the range (the tile you last released the finger at).

If you are not happy with the construction range, instead of confirming it as said above, you can do either of the following:
* Press and drag at the end of the range to change the end of the range
* Tap somewhere else to set the end of the range to that spot
* Press and drag somewhere else to restart the construction range from the pressed spot

When either type of construction is active, if you press-drag next to the edges of the screen, the city will scroll. The closer to the edge your finger is, the faster the scroll will be.

**Cancelling a build**

As mentioned earlier, there is now a button to cancel the build. As an alternative, you can still tap with a second finger to cancel the build. Both options work exactly the same way.

For simple buildings or click-draggable buildings that are not being constructed, clicking the button cancels the selected construction. That means you can navigate the city normally and you'll have to select the proper build button on the sidebar if you want to restart construction.

If you are in the middle of a click-draggable construction, pressing the button will only remove the pending construction. If you don't wish to build anything, you must press the cancel button again.

**Using the map editor**

The map editor works exactly the same way as normal city construction when creating buildings or roads.
For map points, the game works like creating a simple building.
For tiles that use a brush, a simple press/drag and drag will immediately apply the terrain change without having to confirm by clicking again.