### PR TITLE
Fix logging on failure to load music

### DIFF
--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -146,11 +146,11 @@ int sound_device_play_music(const char *filename, int volume_pct)
         data.music = Mix_LoadMUS(filename);
 #endif
         if (!data.music) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO, "Error opening music file '%s'. Reason: %s", filename, Mix_GetError());
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Error opening music file '%s'. Reason: %s", filename, Mix_GetError());
         } else {
             if (Mix_PlayMusic(data.music, -1) == -1) {
                 data.music = 0;
-                SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO, "Error playing music file '%s'. Reason: %s", filename, Mix_GetError());
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Error playing music file '%s'. Reason: %s", filename, Mix_GetError());
             } else {
                 sound_device_set_music_volume(volume_pct);
             }


### PR DESCRIPTION
Even though the error was being logged, the log wasn't printed and never appeared.