### PR TITLE
Small fix for visual bug on visual feedback on delete

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -558,6 +558,7 @@ void building_construction_place(void)
             items_placed = last_items_cleared;
         }
         placement_cost *= items_placed;
+        map_property_clear_constructing_and_deleted();
     } else if (type == BUILDING_WALL) {
         placement_cost *= building_construction_place_wall(0, x_start, y_start, x_end, y_end);
     } else if (type == BUILDING_ROAD) {

--- a/src/widget/city_with_overlay.c
+++ b/src/widget/city_with_overlay.c
@@ -514,8 +514,7 @@ void city_with_overlay_draw(const map_tile *tile)
             draw_animation
         );
         city_building_ghost_draw(tile);
-        city_view_foreach_valid_map_tile(draw_elevated_figures, 0, 0);
-        city_view_foreach_map_tile(clear_deleted);
+        city_view_foreach_map_tile(draw_elevated_figures);
     } else {
         city_view_foreach_map_tile(draw_figures);
         city_view_foreach_map_tile(deletion_draw_terrain_top);

--- a/src/widget/city_without_overlay.c
+++ b/src/widget/city_without_overlay.c
@@ -480,7 +480,7 @@ void city_without_overlay_draw(int selected_figure_id, pixel_coordinate *figure_
         city_view_foreach_valid_map_tile(
             draw_elevated_figures,
             draw_hippodrome_ornaments,
-            clear_deleted
+            0
         );
     } else {
         city_view_foreach_map_tile(deletion_draw_terrain_top);


### PR DESCRIPTION
I thought I had implemented this on #306 but apparently I didn't.

This fixes a visual glitch with visual feedback on delete active where if you move the map while clearing land, finish clearing land and use the minimap to move to a place that was also deleted and out of the current view, the map will flash red for an instant.