### PR TITLE
Android build preparation: Handle virtual keyboard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ set(PLATFORM_FILES
     ${PROJECT_SOURCE_DIR}/src/platform/prefs.c
     ${PROJECT_SOURCE_DIR}/src/platform/sound_device.c
     ${PROJECT_SOURCE_DIR}/src/platform/touch.c
+    ${PROJECT_SOURCE_DIR}/src/platform/virtual_keyboard.c
 )
 
 if (VITA_BUILD)
@@ -438,6 +439,7 @@ set(WIDGET_FILES
     ${PROJECT_SOURCE_DIR}/src/widget/city_overlay_risks.c
     ${PROJECT_SOURCE_DIR}/src/widget/city_with_overlay.c
     ${PROJECT_SOURCE_DIR}/src/widget/city_without_overlay.c
+    ${PROJECT_SOURCE_DIR}/src/widget/input_box.c
     ${PROJECT_SOURCE_DIR}/src/widget/map_editor.c
     ${PROJECT_SOURCE_DIR}/src/widget/map_editor_tool.c
     ${PROJECT_SOURCE_DIR}/src/widget/minimap.c

--- a/src/game/system.h
+++ b/src/game/system.h
@@ -36,6 +36,12 @@ void system_set_fullscreen(int fullscreen);
 void system_set_cursor(int cursor_id);
 
 /**
+ * Returns whether the system uses a virtual keyboard
+ * @return true a virtual keyboard is used, false otherwise
+ */
+int system_use_virtual_keyboard(void);
+
+/**
  * Exit the game
  */
 void system_exit(void);

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -3,6 +3,7 @@
 #include "core/encoding.h"
 #include "core/string.h"
 #include "graphics/text.h"
+#include "platform/virtual_keyboard.h"
 
 static struct {
     int insert;
@@ -55,7 +56,7 @@ static void set_offset_to_end(void)
     }
 }
 
-void keyboard_start_capture(uint8_t *text, int max_length, int allow_punctuation, int box_width, font_t font)
+void keyboard_start_capture(uint8_t *text, int max_length, int allow_punctuation, const input_box *capture_box, font_t font)
 {
     data.capture = 1;
     data.text = text;
@@ -64,9 +65,10 @@ void keyboard_start_capture(uint8_t *text, int max_length, int allow_punctuation
     data.max_length = max_length;
     data.allow_punctuation = allow_punctuation;
     data.accepted = 0;
-    data.box_width = box_width;
+    data.box_width = (capture_box->w - 2) * INPUT_BOX_BLOCK_SIZE;
     data.font = font;
     set_offset_to_end();
+    platform_virtual_keyboard_start();
 }
 
 void keyboard_refresh(void)
@@ -79,11 +81,13 @@ void keyboard_refresh(void)
 void keyboard_resume_capture(void)
 {
     data.capture = 1;
+    platform_virtual_keyboard_resume();
 }
 
 void keyboard_pause_capture(void)
 {
     data.capture = 0;
+    platform_virtual_keyboard_stop();
 }
 
 void keyboard_stop_capture(void)
@@ -94,6 +98,7 @@ void keyboard_stop_capture(void)
     data.length = 0;
     data.max_length = 0;
     data.accepted = 0;
+    platform_virtual_keyboard_stop();
 }
 
 int keyboard_input_is_accepted(void)

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -65,10 +65,9 @@ void keyboard_start_capture(uint8_t *text, int max_length, int allow_punctuation
     data.max_length = max_length;
     data.allow_punctuation = allow_punctuation;
     data.accepted = 0;
-    data.box_width = (capture_box->w - 2) * INPUT_BOX_BLOCK_SIZE;
+    data.box_width = (capture_box->width_blocks - 2) * INPUT_BOX_BLOCK_SIZE;
     data.font = font;
     set_offset_to_end();
-    platform_virtual_keyboard_start();
 }
 
 void keyboard_refresh(void)
@@ -81,13 +80,12 @@ void keyboard_refresh(void)
 void keyboard_resume_capture(void)
 {
     data.capture = 1;
-    platform_virtual_keyboard_resume();
 }
 
 void keyboard_pause_capture(void)
 {
     data.capture = 0;
-    platform_virtual_keyboard_stop();
+    platform_virtual_keyboard_hide();
 }
 
 void keyboard_stop_capture(void)
@@ -98,7 +96,7 @@ void keyboard_stop_capture(void)
     data.length = 0;
     data.max_length = 0;
     data.accepted = 0;
-    platform_virtual_keyboard_stop();
+    platform_virtual_keyboard_hide();
 }
 
 int keyboard_input_is_accepted(void)

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -2,10 +2,11 @@
 #define INPUT_KEYBOARD_H
 
 #include "graphics/font.h"
+#include "widget/input_box.h"
 
 #include <stdint.h>
 
-void keyboard_start_capture(uint8_t *text, int max_length, int allow_punctuation, int box_width, font_t font);
+void keyboard_start_capture(uint8_t *text, int max_length, int allow_punctuation, const input_box *capture_box, font_t font);
 void keyboard_refresh(void);
 void keyboard_resume_capture(void);
 void keyboard_pause_capture(void);

--- a/src/platform/keyboard_input.c
+++ b/src/platform/keyboard_input.c
@@ -1,5 +1,6 @@
 #include "keyboard_input.h"
 
+#include "game/system.h"
 #include "input/hotkey.h"
 #include "input/keyboard.h"
 
@@ -168,4 +169,13 @@ void platform_handle_key_up(SDL_KeyboardEvent *event)
 void platform_handle_text(SDL_TextInputEvent *event)
 {
     keyboard_character(event->text);
+}
+
+int system_use_virtual_keyboard(void)
+{
+#if defined (__vita__) || defined(__SWITCH__)
+    return 1;
+#else
+    return 0;
+#endif
 }

--- a/src/platform/virtual_keyboard.c
+++ b/src/platform/virtual_keyboard.c
@@ -4,39 +4,16 @@
 
 #include "SDL.h"
 
-static int active;
-
-void platform_virtual_keyboard_start(void)
-{
-    if (system_use_virtual_keyboard()) {
-        SDL_StopTextInput();
-    }
-    active = 1;
-}
-
-void platform_virtual_keyboard_resume(void)
-{
-    active = 1;
-}
-
-void platform_virtual_keyboard_stop(void)
-{
-    if (system_use_virtual_keyboard()) {
-        SDL_StopTextInput();
-    }
-    active = 0;
-}
-
 void platform_virtual_keyboard_show(void)
 {
-    if (active && system_use_virtual_keyboard()) {
+    if (system_use_virtual_keyboard()) {
         SDL_StartTextInput();
     }
 }
 
 void platform_virtual_keyboard_hide(void)
 {
-    if (active && system_use_virtual_keyboard()) {
+    if (system_use_virtual_keyboard()) {
         SDL_StopTextInput();
     }
 }

--- a/src/platform/virtual_keyboard.c
+++ b/src/platform/virtual_keyboard.c
@@ -1,0 +1,47 @@
+#include "virtual_keyboard.h"
+
+#include "game/system.h"
+
+#include "SDL.h"
+
+static int active;
+
+void platform_virtual_keyboard_start(void)
+{
+    if (system_use_virtual_keyboard()) {
+        SDL_StopTextInput();
+    }
+    active = 1;
+}
+
+void platform_virtual_keyboard_resume(void)
+{
+    active = 1;
+}
+
+void platform_virtual_keyboard_stop(void)
+{
+    if (system_use_virtual_keyboard()) {
+        SDL_StopTextInput();
+    }
+    active = 0;
+}
+
+void platform_virtual_keyboard_show(void)
+{
+    if (active && system_use_virtual_keyboard()) {
+        SDL_StartTextInput();
+    }
+}
+
+void platform_virtual_keyboard_hide(void)
+{
+    if (active && system_use_virtual_keyboard()) {
+        SDL_StopTextInput();
+    }
+}
+
+int platform_virtual_keyboard_showing(void)
+{
+    return SDL_IsTextInputActive();
+}

--- a/src/platform/virtual_keyboard.h
+++ b/src/platform/virtual_keyboard.h
@@ -1,0 +1,11 @@
+#ifndef PLATFORM_VIRTUAL_KEYBOARD_H
+#define PLATFORM_VIRTUAL_KEYBOARD_H
+
+void platform_virtual_keyboard_start(void);
+void platform_virtual_keyboard_resume(void);
+void platform_virtual_keyboard_stop(void);
+void platform_virtual_keyboard_show(void);
+void platform_virtual_keyboard_hide(void);
+int platform_virtual_keyboard_showing(void);
+
+#endif // PLATFORM_VIRTUAL_KEYBOARD_H

--- a/src/platform/virtual_keyboard.h
+++ b/src/platform/virtual_keyboard.h
@@ -1,9 +1,6 @@
 #ifndef PLATFORM_VIRTUAL_KEYBOARD_H
 #define PLATFORM_VIRTUAL_KEYBOARD_H
 
-void platform_virtual_keyboard_start(void);
-void platform_virtual_keyboard_resume(void);
-void platform_virtual_keyboard_stop(void);
 void platform_virtual_keyboard_show(void);
 void platform_virtual_keyboard_hide(void);
 int platform_virtual_keyboard_showing(void);

--- a/src/widget/input_box.c
+++ b/src/widget/input_box.c
@@ -1,0 +1,29 @@
+#include "input_box.h"
+
+#include "graphics/panel.h"
+#include "platform/virtual_keyboard.h"
+
+static int is_mouse_inside_input(const mouse *m, const input_box *box)
+{
+    return (m->x > box->x && m->x < box->x + box->w * INPUT_BOX_BLOCK_SIZE &&
+            m->y > box->y && m->y < box->y + box->h * INPUT_BOX_BLOCK_SIZE);
+}
+
+int input_box_handle_mouse(const mouse *m, const input_box *box)
+{
+    if (!m->left.went_up) {
+        return 0;
+    }
+    int selected = is_mouse_inside_input(m, box);
+    if (!platform_virtual_keyboard_showing() && selected) {
+        platform_virtual_keyboard_show();
+    } else if (platform_virtual_keyboard_showing() && !selected) {
+        platform_virtual_keyboard_hide();
+    }
+    return selected;
+}
+
+void input_box_draw(const input_box *box)
+{
+    inner_panel_draw(box->x, box->y, box->w, box->h);
+}

--- a/src/widget/input_box.c
+++ b/src/widget/input_box.c
@@ -5,8 +5,13 @@
 
 static int is_mouse_inside_input(const mouse *m, const input_box *box)
 {
-    return (m->x > box->x && m->x < box->x + box->w * INPUT_BOX_BLOCK_SIZE &&
-            m->y > box->y && m->y < box->y + box->h * INPUT_BOX_BLOCK_SIZE);
+    return m->x >= box->x && m->x < box->x + box->width_blocks  * INPUT_BOX_BLOCK_SIZE &&
+           m->y >= box->y && m->y < box->y + box->height_blocks * INPUT_BOX_BLOCK_SIZE;
+}
+
+void input_box_draw(const input_box *box)
+{
+    inner_panel_draw(box->x, box->y, box->width_blocks, box->height_blocks);
 }
 
 int input_box_handle_mouse(const mouse *m, const input_box *box)
@@ -21,9 +26,4 @@ int input_box_handle_mouse(const mouse *m, const input_box *box)
         platform_virtual_keyboard_hide();
     }
     return selected;
-}
-
-void input_box_draw(const input_box *box)
-{
-    inner_panel_draw(box->x, box->y, box->w, box->h);
 }

--- a/src/widget/input_box.h
+++ b/src/widget/input_box.h
@@ -8,8 +8,8 @@
 typedef struct {
     int x;
     int y;
-    int w;
-    int h;
+    int width_blocks;
+    int height_blocks;
 } input_box;
 
 int input_box_handle_mouse(const mouse *m, const input_box *box);

--- a/src/widget/input_box.h
+++ b/src/widget/input_box.h
@@ -1,0 +1,18 @@
+#ifndef WIDGET_INPUT_BOX_H
+#define WIDGET_INPUT_BOX_H
+
+#include "input/mouse.h"
+
+#define INPUT_BOX_BLOCK_SIZE 16
+
+typedef struct {
+    int x;
+    int y;
+    int w;
+    int h;
+} input_box;
+
+int input_box_handle_mouse(const mouse *m, const input_box *box);
+void input_box_draw(const input_box *box);
+
+#endif // WIDGET_INPUT_BOX_H

--- a/src/window/editor/attributes.c
+++ b/src/window/editor/attributes.c
@@ -17,6 +17,7 @@
 #include "input/keyboard.h"
 #include "scenario/editor.h"
 #include "scenario/property.h"
+#include "widget/input_box.h"
 #include "widget/minimap.h"
 #include "widget/sidebar_editor.h"
 #include "window/editor/allowed_buildings.h"
@@ -62,6 +63,8 @@ static arrow_button image_arrows[] = {
     {44, 424, 21, 24, change_image, 1, 0},
 };
 
+static input_box scenario_description_input = { 92, 40, 19, 2 };
+
 static struct {
     int is_paused;
     uint8_t brief_description[BRIEF_DESC_LENGTH];
@@ -74,7 +77,7 @@ static void start(void)
         keyboard_resume_capture();
     } else {
         string_copy(scenario_brief_description(), data.brief_description, BRIEF_DESC_LENGTH);
-        keyboard_start_capture(data.brief_description, BRIEF_DESC_LENGTH, 1, 280, FONT_NORMAL_WHITE);
+        keyboard_start_capture(data.brief_description, BRIEF_DESC_LENGTH, 1, &scenario_description_input, FONT_NORMAL_WHITE);
     }
 }
 
@@ -99,7 +102,7 @@ static void draw_foreground(void)
     graphics_in_dialog();
     outer_panel_draw(0, 28, 30, 28);
 
-    inner_panel_draw(92, 40, 19, 2);
+    input_box_draw(&scenario_description_input);
     text_capture_cursor(keyboard_cursor_position(), keyboard_offset_start(), keyboard_offset_end());
     text_draw(data.brief_description, 100, 50, FONT_NORMAL_WHITE, 0);
     text_draw_cursor(100, 51, keyboard_is_insert());
@@ -172,6 +175,9 @@ static void handle_mouse(const mouse *m)
         window_editor_map_show();
     } else {
         const mouse *m_dialog = mouse_in_dialog(m);
+        if (input_box_handle_mouse(m_dialog, &scenario_description_input)) {
+            return;
+        }
         if (!generic_buttons_handle_mouse(m_dialog, 0, 0, buttons, 10, &data.focus_button_id)) {
             if (!arrow_buttons_handle_mouse(m_dialog, 0, 0, image_arrows, 2)) {
                 widget_sidebar_editor_handle_mouse_attributes(m);

--- a/src/window/new_career.c
+++ b/src/window/new_career.c
@@ -14,6 +14,7 @@
 #include "input/keyboard.h"
 #include "scenario/property.h"
 #include "scenario/scenario.h"
+#include "widget/input_box.h"
 #include "window/mission_selection.h"
 
 static void start_mission(int param1, int param2);
@@ -24,6 +25,8 @@ static image_button image_buttons[] = {
     {305, 0, 27, 27, IB_NORMAL, GROUP_SIDEBAR_BUTTONS, 56, start_mission, button_none, 1, 0, 1}
 };
 
+static input_box player_name_input = { 160, 208, 20, 2 };
+
 static uint8_t player_name[32];
 
 static void init(void)
@@ -31,7 +34,7 @@ static void init(void)
     setting_clear_personal_savings();
     scenario_settings_init();
     string_copy(lang_get_string(9, 5), player_name, 32);
-    keyboard_start_capture(player_name, 32, 1, 280, FONT_NORMAL_WHITE);
+    keyboard_start_capture(player_name, 32, 1, &player_name_input, FONT_NORMAL_WHITE);
 }
 
 static void draw_background(void)
@@ -49,7 +52,7 @@ static void draw_foreground(void)
     lang_text_draw_centered(31, 0, 128, 172, 384, FONT_LARGE_BLACK);
     lang_text_draw(13, 5, 352, 256, FONT_NORMAL_BLACK);
     lang_text_draw(12, 0, 200, 256, FONT_NORMAL_BLACK);
-    inner_panel_draw(160, 208, 20, 2);
+    input_box_draw(&player_name_input);
     text_capture_cursor(keyboard_cursor_position(), keyboard_offset_start(), keyboard_offset_end());
     text_draw(player_name, 176, 216, FONT_NORMAL_WHITE, 0);
     text_draw_cursor(176, 217, keyboard_is_insert());
@@ -66,7 +69,9 @@ static void handle_mouse(const mouse *m)
         window_go_back();
     }
 
-    if (image_buttons_handle_mouse(mouse_in_dialog(m), 159, 249, image_buttons, 2, 0)) {
+    const mouse *m_dialog = mouse_in_dialog(m);
+    if (input_box_handle_mouse(m_dialog, &player_name_input) ||
+        image_buttons_handle_mouse(m_dialog, 159, 249, image_buttons, 2, 0)) {
         return;
     }
     if (keyboard_input_is_accepted()) {

--- a/src/window/new_career.c
+++ b/src/window/new_career.c
@@ -67,6 +67,7 @@ static void handle_mouse(const mouse *m)
     if (m->right.went_up) {
         keyboard_stop_capture();
         window_go_back();
+        return;
     }
 
     const mouse *m_dialog = mouse_in_dialog(m);


### PR DESCRIPTION
This only works for platforms which use a virtual keyboard, which are Switch, Vita and Android.

This allows the virtual keyboard to display automatically when the input box is pressed.

It may already work with Vita and Switch, but it's untested. On the worst case it should behave exactly like until now.