### PR TITLE
Drop unnecessary check on unsigned values

### DIFF
--- a/src/widget/city_figure.c
+++ b/src/widget/city_figure.c
@@ -116,9 +116,6 @@ static void draw_fort_standard(const figure *f, int x, int y)
 
 static void draw_map_flag(const figure *f, int x, int y)
 {
-    if (f->y < 0 || f->x < 0) {
-        return;
-    }
     // base
     image_draw(f->image_id, x, y);
     // flag


### PR DESCRIPTION
Both figure.x and y are of unsigned char type and cannot be less than 0

https://github.com/bvschaik/julius/blob/b8e0fede7cc88b35e9bf6a0af978458f0aa5650e/src/figure/figure.h#L32-L33