### PR TITLE
Fix a crash when building draggable reservoirs

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -737,6 +737,11 @@ void building_construction_get_view_position(int *view_x, int *view_y)
     *view_y = data.start_offset_y_view;
 }
 
+int building_construction_get_start_grid_offset(void)
+{
+    return data.start.grid_offset;
+}
+
 void building_construction_reset_draw_as_constructing(void)
 {
     data.draw_as_constructing = 0;

--- a/src/building/construction.h
+++ b/src/building/construction.h
@@ -32,6 +32,7 @@ int building_construction_road_orientation(void);
 
 void building_construction_record_view_position(int view_x, int view_y, int grid_offset);
 void building_construction_get_view_position(int *view_x, int *view_y);
+int building_construction_get_start_grid_offset(void);
 
 void building_construction_reset_draw_as_constructing(void);
 int building_construction_draw_as_constructing(void);

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -355,9 +355,7 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
                 draw_flat_tile(x_start + X_VIEW_OFFSETS[i], y_start + Y_VIEW_OFFSETS[i], COLOR_MASK_RED);
             }
         } else {
-            view_tile view;
-            city_view_pixels_to_view_tile(x_start, y_start, &view);
-            offset = city_view_tile_to_grid_offset(&view);
+            offset = building_construction_get_start_grid_offset();
             if (offset != reservoir_range_data.last_grid_offset) {
                 reservoir_range_data.last_grid_offset = offset;
                 reservoir_range_data.total = 0;
@@ -386,7 +384,7 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
             }
             if (!draw_later) {
                 if (config_get(CONFIG_UI_SHOW_WATER_STRUCTURE_RANGE)) {
-                    city_view_foreach_tile_in_range(offset + 1, 3, 10, draw_first_reservoir_range);
+                    city_view_foreach_tile_in_range(offset - GRID_SIZE - 1, 3, 10, draw_first_reservoir_range);
                     city_view_foreach_tile_in_range(tile->grid_offset - GRID_SIZE - 1, 3, 10, draw_second_reservoir_range);
                 }
                 draw_single_reservoir(x_start, y_start, has_water);
@@ -405,7 +403,7 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
     } else {
         if (config_get(CONFIG_UI_SHOW_WATER_STRUCTURE_RANGE) && (!building_construction_in_progress() || draw_later)) {
             if (draw_later) {
-                city_view_foreach_tile_in_range(offset + 1, 3, 10, draw_first_reservoir_range);
+                city_view_foreach_tile_in_range(offset - GRID_SIZE - 1, 3, 10, draw_first_reservoir_range);
             }
             city_view_foreach_tile_in_range(tile->grid_offset - GRID_SIZE - 1, 3, 10, draw_second_reservoir_range);
         }


### PR DESCRIPTION
The crash happened only when creating draggable reservoirs, and only when the first reservoir was out of the city view.

This happened because I was stupid and calculated the original reservoir's `grid_offset` based on the `view_tile` (which is only valid when the tile is, well, being viewed), instead of directly fetching the `grid_offset` that was conveniently already available on `building_construction.c`'s `data` variable.