### PR TITLE
Zoom preparation: add support for middle mouse button click

### DIFF
--- a/src/input/mouse.c
+++ b/src/input/mouse.c
@@ -54,6 +54,8 @@ void mouse_set_from_touch(const touch *first, const touch *last)
     data.right.is_down = (!last->has_ended && last->in_use);
     data.right.went_down = last->has_started;
     data.right.went_up = last->has_ended;
+
+    clear_mouse_button(&data.middle);
 }
 
 void mouse_set_position(int x, int y)
@@ -77,6 +79,14 @@ void mouse_set_left_down(int down)
         data.left.system_change |= ((last_click < now) && ((now - last_click) <= DOUBLE_CLICK_TIME)) ? SYSTEM_DOUBLE_CLICK : SYSTEM_NONE;
         last_click = now;
     }
+}
+
+void mouse_set_middle_down(int down)
+{
+    data.middle.system_change |= down ? SYSTEM_DOWN : SYSTEM_UP;
+    data.is_touch = 0;
+    data.is_inside_window = 1;
+    last_click = 0;
 }
 
 void mouse_set_right_down(int down)
@@ -106,6 +116,7 @@ static void update_button_state(mouse_button *button)
 void mouse_determine_button_state(void)
 {
     update_button_state(&data.left);
+    update_button_state(&data.middle);
     update_button_state(&data.right);
 }
 
@@ -124,6 +135,7 @@ void mouse_reset_scroll(void)
 void mouse_reset_up_state(void)
 {
     data.left.went_up = 0;
+    data.middle.went_up = 0;
     data.right.went_up = 0;
 }
 
@@ -131,12 +143,14 @@ void mouse_reset_button_state(void)
 {
     last_click = 0;
     clear_mouse_button(&data.left);
+    clear_mouse_button(&data.middle);
     clear_mouse_button(&data.right);
 }
 
 const mouse *mouse_in_dialog(const mouse *m)
 {
     dialog.left = m->left;
+    dialog.middle = m->middle;
     dialog.right = m->right;
     dialog.scrolled = m->scrolled;
     dialog.is_inside_window = m->is_inside_window;

--- a/src/input/mouse.h
+++ b/src/input/mouse.h
@@ -33,6 +33,7 @@ typedef struct {
     int y; /**< Global position Y */
     scroll_state scrolled; /**< Scroll state (up/down/none) */
     mouse_button left; /**< Left mouse button */
+    mouse_button middle; /**< Middle mouse button */
     mouse_button right; /**< Right mouse button */
     int is_inside_window; /**< Whether the mouse is in the window */
     int is_touch; /**< Whether the mouse is a translated touch event */
@@ -52,6 +53,8 @@ const mouse *mouse_get(void);
 void mouse_set_position(int x, int y);
 
 void mouse_set_left_down(int down);
+
+void mouse_set_middle_down(int down);
 
 void mouse_set_right_down(int down);
 

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -190,6 +190,8 @@ static void handle_mouse_button(SDL_MouseButtonEvent *event, int is_down)
     mouse_set_position(event->x, event->y);
     if (event->button == SDL_BUTTON_LEFT) {
         mouse_set_left_down(is_down);
+    } else if (event->button == SDL_BUTTON_MIDDLE) {
+        mouse_set_middle_down(is_down);
     } else if (event->button == SDL_BUTTON_RIGHT) {
         mouse_set_right_down(is_down);
     }


### PR DESCRIPTION
Zooming will restore the city scale to default upon clicking on the middle mouse button.

So I'm providing middle mouse button support in a separate PR, so as not to add to much code at the same time.