### PR TITLE
Support building with system libpng

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,9 +41,9 @@ before_build:
   - if [%COMPILER%] == [mingw-w64] set Path=%MINGW_W64_PATH%\mingw64\bin;%Path%
   - md build
   - cd build
-  - if [%COMPILER%] == [mingw] cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -D CMAKE_C_COMPILER=mingw32-gcc.exe -D CMAKE_MAKE_PROGRAM=mingw32-make.exe ..
-  - if [%COMPILER%] == [mingw-w64] cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -D CMAKE_C_COMPILER=x86_64-w64-mingw32-gcc.exe -D CMAKE_MAKE_PROGRAM=mingw32-make.exe ..
-  - if [%COMPILER%] == [msvc] cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -DCMAKE_PREFIX_PATH=C:/sdl-msvc/SDL2-%SDL2_VERSION%;C:/sdl-msvc/SDL2_mixer-%SDL2_MIXER_VERSION% ..
+  - if [%COMPILER%] == [mingw] cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -DSYSTEM_LIBS=OFF -D CMAKE_C_COMPILER=mingw32-gcc.exe -D CMAKE_MAKE_PROGRAM=mingw32-make.exe ..
+  - if [%COMPILER%] == [mingw-w64] cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -DSYSTEM_LIBS=OFF -D CMAKE_C_COMPILER=x86_64-w64-mingw32-gcc.exe -D CMAKE_MAKE_PROGRAM=mingw32-make.exe ..
+  - if [%COMPILER%] == [msvc] cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% -DSYSTEM_LIBS=OFF -DCMAKE_PREFIX_PATH=C:/sdl-msvc/SDL2-%SDL2_VERSION%;C:/sdl-msvc/SDL2_mixer-%SDL2_MIXER_VERSION% ..
 
 build_script:
   - cmake --build .

--- a/.ci_scripts/run_cmake.sh
+++ b/.ci_scripts/run_cmake.sh
@@ -12,13 +12,13 @@ case "$BUILD_TARGET" in
 	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSWITCH_BUILD=ON ..
 	;;
 "mac")
-	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSYSTEM_LIBS=OFF ..
 	;;
 "appimage")
-	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ..
+	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSYSTEM_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/usr ..
 	;;
 "linux")
-	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSYSTEM_LIBS=OFF ..
 	;;
 *)
 	mkdir build && cd build && cmake ..

--- a/.ci_scripts/setup_environment.sh
+++ b/.ci_scripts/setup_environment.sh
@@ -13,6 +13,7 @@ case "$BUILD_TARGET" in
 	vdpm sdl2_mixer
 	vdpm mpg123
 	vdpm libogg
+	vdpm libpng
 	vdpm libvorbis
 	vdpm libmikmod
 	vdpm flac
@@ -20,6 +21,6 @@ case "$BUILD_TARGET" in
 "switch")
 	wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb
 	sudo dpkg -i devkitpro-pacman.deb
-	sudo dkp-pacman -Syyu --noconfirm devkitA64 devkitpro-pkgbuild-helpers libnx switch-tools switch-sdl2 switch-sdl2_mixer
+	sudo dkp-pacman -Syyu --noconfirm devkitA64 devkitpro-pkgbuild-helpers libnx switch-tools switch-sdl2 switch-sdl2_mixer switch-libpng
 	;;
 esac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ if(VITA_BUILD AND SWITCH_BUILD)
 endif()
 
 option(DRAW_FPS "Draw FPS on the top left corner of the window." OFF)
+option(SYSTEM_LIBS "Use system libraries when available." ON)
 cmake_dependent_option(VITA_BUILD "Build for the PlayStation Vita handheld game console." OFF "NOT MSVC" OFF)
 cmake_dependent_option(SWITCH_BUILD "Build for the Nintendo Switch handheld game console." OFF "NOT MSVC; NOT VITA_BUILD" OFF)
 
@@ -574,9 +575,7 @@ set(SOURCE_FILES
     ${WINDOW_FILES}
     ${EDITOR_FILES}
     ${TRANSLATION_FILES}
-    ${PNG_FILES}
     ${TINYFD_FILES}
-    ${ZLIB_FILES}
     ${PROJECT_SOURCE_DIR}/res/julius.rc
     ${MACOSX_FILES}
 )
@@ -670,6 +669,17 @@ endif()
 
 include_directories(${SDL2_INCLUDE_DIR})
 include_directories(${SDL2_MIXER_INCLUDE_DIR})
+
+if(SYSTEM_LIBS)
+    find_package(PNG)
+endif()
+if(PNG_FOUND)
+    include_directories(${PNG_INCLUDE_DIRS})
+    target_link_libraries(${SHORT_NAME} ${PNG_LIBRARIES})
+else()
+    include_directories("ext/png")
+    target_sources(${SHORT_NAME} PRIVATE "${PNG_FILES}" "${ZLIB_FILES}")
+endif()
 
 if(VITA_BUILD)
     include_directories(

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -9,6 +9,7 @@ To build Julius, you'll need:
 - `cmake`
 - `SDL2`
 - `SDL2_mixer`
+- `libpng` (optional, a bundled copy will be used if not found)
 
 After cloning the repo (URL: `https://github.com/bvschaik/julius.git`), run the following commands:
 
@@ -17,6 +18,8 @@ After cloning the repo (URL: `https://github.com/bvschaik/julius.git`), run the 
 	$ make
 
 This results in a `julius` executable.
+
+To use the bundled copies of optional libraries even if a system version is available, add `-DSYSTEM_LIBS=OFF` to `cmake` invocation.
 
 To build the Vita or Switch versions, use `cmake .. -DVITA_BUILD=ON` or `cmake .. -DSWITCH_BUILD=ON`
 instead of `cmake ..`.

--- a/doc/building_linux.md
+++ b/doc/building_linux.md
@@ -12,6 +12,7 @@ In order to follow these instructions, you'll need to install the following pack
 * `SDL2`
 * `SDL2_mixer`
 * `cmake`
+- `libpng` (optional, a bundled copy will be used if not found)
 
 Then skip steps 1. and 2. of the Ubuntu instructions.
 
@@ -23,7 +24,7 @@ of `sudo`.
 
 1. Open a terminal window and type the following command to install all the needed dependencies:
 
-        $ sudo apt install git libsdl2-dev libsdl2-mixer-dev cmake
+        $ sudo apt install git libsdl2-dev libsdl2-mixer-dev cmake libpng-dev
 
 2. Depending on what you already have installed, `apt` may ask you to install many packages.
    Confirm the installation.

--- a/src/graphics/screenshot.c
+++ b/src/graphics/screenshot.c
@@ -12,7 +12,7 @@
 #include "map/grid.h"
 #include "widget/city_without_overlay.h"
 
-#include "png/png.h"
+#include "png.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
As discussed in #432, this adds the (now default) option to link with system libpng. If it’s not found, or cmake is run with `-DSYSTEM_LIBS=OFF`, it will fall back to the bundled copy. The second commit notes the new optional dependency in the docs.

I updated the CI scripts for `vita` and `switch` to build with libpng from the respective repos. The `mac`, `appimage` and `linux` targets are now built with `-DSYSTEM_LIBS=OFF` to ensure portability; same for the Windows build.

I can only test the game on Linux, where all cases (libpng present/missing, SYSTEM_LIBS ON/OFF) build and run OK. I was also able to build for switch and vita.

Please let me know if there’s anything to change or improve. Thanks!