### PR TITLE
Fix esc button not working in the city view when touch is active

### DIFF
--- a/src/widget/city.c
+++ b/src/widget/city.c
@@ -389,15 +389,8 @@ int widget_city_has_input(void)
     return data.capture_input;
 }
 
-void widget_city_handle_input(const mouse *m, const hotkeys *h)
+static void handle_mouse(const mouse *m)
 {
-    scroll_map(m);
-
-    if (m->is_touch) {
-        handle_touch();
-        return;
-    }
-
     if (m->right.is_down && !m->right.went_down) {
         scroll_drag_move();
     }
@@ -432,6 +425,18 @@ void widget_city_handle_input(const mouse *m, const hotkeys *h)
             building_construction_cancel();
         }
     }
+}
+
+void widget_city_handle_input(const mouse *m, const hotkeys *h)
+{
+    scroll_map(m);
+
+    if (m->is_touch) {
+        handle_touch();
+    } else {
+        handle_mouse(m);
+    }
+
     if (h->escape_pressed) {
         if (building_construction_type()) {
             building_construction_cancel();

--- a/src/widget/map_editor.c
+++ b/src/widget/map_editor.c
@@ -304,22 +304,22 @@ void widget_map_editor_handle_input(const mouse *m, const hotkeys *h)
 
     if (m->is_touch) {
         handle_touch();
-        return;
-    }
-    if (m->right.is_down && !m->right.went_down) {
-        scroll_drag_move();
-    }
-    if (m->right.went_down && input_coords_in_map(m->x, m->y) && !editor_tool_is_active()) {
-        scroll_drag_start(0);
-    }
-    if (m->right.went_up) {
-        if (!editor_tool_is_active()) {
-            int has_scrolled = scroll_drag_end();
-            if (!has_scrolled) {
+    } else {
+        if (m->right.is_down && !m->right.went_down) {
+            scroll_drag_move();
+        }
+        if (m->right.went_down && input_coords_in_map(m->x, m->y) && !editor_tool_is_active()) {
+            scroll_drag_start(0);
+        }
+        if (m->right.went_up) {
+            if (!editor_tool_is_active()) {
+                int has_scrolled = scroll_drag_end();
+                if (!has_scrolled) {
+                    editor_tool_deactivate();
+                }
+            } else {
                 editor_tool_deactivate();
             }
-        } else {
-            editor_tool_deactivate();
         }
     }
 


### PR DESCRIPTION
When touch was active, the game never reached `h->escape_pressed`, so the "Exit Game" window never got triggered.