### PR TITLE
Fix some more reservoir range bugs

### DIFF
--- a/src/city/view.c
+++ b/src/city/view.c
@@ -567,9 +567,14 @@ void city_view_foreach_tile_in_range(int grid_offset, int size, int radius, map_
     y = (y - data.camera.tile.y - 1) * HALF_TILE_HEIGHT_PIXELS - data.camera.pixel.y + data.viewport.y;
     int orientation_x = X_DIRECTION_FOR_ORIENTATION[data.orientation / 2];
     int orientation_y = Y_DIRECTION_FOR_ORIENTATION[data.orientation / 2];
-    int pixel_rotation = orientation_x * orientation_y;
-    int rotation_delta = pixel_rotation == -1 ? (2 - size) : 1;
 
+    // If we are rotated east or west, the pixel location needs to be rotated
+    // to match its corresponding grid_offset. Since for east and west
+    // only one of the orientations is negative, we can get a negative value
+    // which can then be used to properly offset the pixel positions
+    int pixel_rotation = orientation_x * orientation_y;
+
+    int rotation_delta = pixel_rotation == -1 ? (2 - size) : 1;
     grid_offset += map_grid_delta(rotation_delta * orientation_x, rotation_delta * orientation_y);
     int x_delta = HALF_TILE_WIDTH_PIXELS;
     int y_delta = HALF_TILE_HEIGHT_PIXELS;
@@ -583,6 +588,10 @@ void city_view_foreach_tile_in_range(int grid_offset, int size, int radius, map_
     } else {
         do_valid_callback(x, y, grid_offset, callback);
     }
+    // Basic algorithm: we cycle the radius as successive rings
+    // Starting at the innermost ring (determined by size), we first cycle
+    // the top, left, right and bottom corners of the ring.
+    // Then we stretch from each corner of the ring to reach the next one, closing the ring
     for (int ring = 0; ring < radius; ++ring) {
         int offset_north = -ring - 2;
         int offset_south = ring + size;

--- a/src/widget/city_building_ghost.c
+++ b/src/widget/city_building_ghost.c
@@ -73,6 +73,8 @@ static const int FORT_GROUND_GRID_OFFSETS[4] = {OFFSET(3,-1), OFFSET(4,-1), OFFS
 static const int FORT_GROUND_X_VIEW_OFFSETS[4] = {120, 90, -120, -90};
 static const int FORT_GROUND_Y_VIEW_OFFSETS[4] = {30, -75, -60, 45};
 
+static const int RESERVOIR_GRID_OFFSETS[4] = {OFFSET(-1,-1), OFFSET(1,-1), OFFSET(1,1), OFFSET(-1,1)};
+
 static const int HIPPODROME_X_VIEW_OFFSETS[4] = {150, 150, -150, -150};
 static const int HIPPODROME_Y_VIEW_OFFSETS[4] = {75, -75, -75, 75};
 
@@ -349,6 +351,7 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
     int draw_later = 0;
     int x_start, y_start, offset;
     int has_water = map_terrain_exists_tile_in_area_with_type(map_x - 1, map_y - 1, 5, TERRAIN_WATER);
+    int orientation_index = city_view_orientation() / 2;
     if (building_construction_in_progress()) {
         building_construction_get_view_position(&x_start, &y_start);
         y_start -= 30;
@@ -386,8 +389,8 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
             }
             if (!draw_later) {
                 if (config_get(CONFIG_UI_SHOW_WATER_STRUCTURE_RANGE)) {
-                    city_view_foreach_tile_in_range(offset + map_grid_delta(-1,-1), 3, 10, draw_first_reservoir_range);
-                    city_view_foreach_tile_in_range(tile->grid_offset + map_grid_delta(-1,-1), 3, 10, draw_second_reservoir_range);
+                    city_view_foreach_tile_in_range(offset + RESERVOIR_GRID_OFFSETS[orientation_index], 3, 10, draw_first_reservoir_range);
+                    city_view_foreach_tile_in_range(tile->grid_offset + RESERVOIR_GRID_OFFSETS[orientation_index], 3, 10, draw_second_reservoir_range);
                 }
                 draw_single_reservoir(x_start, y_start, has_water);
             }
@@ -405,9 +408,9 @@ static void draw_draggable_reservoir(const map_tile *tile, int x, int y)
     } else {
         if (config_get(CONFIG_UI_SHOW_WATER_STRUCTURE_RANGE) && (!building_construction_in_progress() || draw_later)) {
             if (draw_later) {
-                city_view_foreach_tile_in_range(offset + map_grid_delta(-1,-1), 3, 10, draw_first_reservoir_range);
+                city_view_foreach_tile_in_range(offset + RESERVOIR_GRID_OFFSETS[orientation_index], 3, 10, draw_first_reservoir_range);
             }
-            city_view_foreach_tile_in_range(tile->grid_offset + map_grid_delta(-1,-1), 3, 10, draw_second_reservoir_range);
+            city_view_foreach_tile_in_range(tile->grid_offset + RESERVOIR_GRID_OFFSETS[orientation_index], 3, 10, draw_second_reservoir_range);
         }
         draw_single_reservoir(x, y, has_water);
         if (draw_later) {


### PR DESCRIPTION
Orientation wasn't being factored to properly determine the range, so reservoirs only worked for the North (default) orientation.

Fix #452.