### PR TITLE
Further refactor sidebar code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,7 @@ set(WIDGET_FILES
     ${PROJECT_SOURCE_DIR}/src/widget/sidebar/common.c
     ${PROJECT_SOURCE_DIR}/src/widget/sidebar/editor.c
     ${PROJECT_SOURCE_DIR}/src/widget/sidebar/extra.c
+    ${PROJECT_SOURCE_DIR}/src/widget/sidebar/slide.c
 )
 set(WINDOW_FILES
     ${PROJECT_SOURCE_DIR}/src/window/advisors.c

--- a/src/widget/sidebar/common.c
+++ b/src/widget/sidebar/common.c
@@ -15,12 +15,9 @@ int sidebar_common_get_x_offset_collapsed(void)
     return screen_width() - SIDEBAR_COLLAPSED_WIDTH;
 }
 
-void sidebar_common_draw_minimap(int y_offset, int force)
+int sidebar_common_get_height(void)
 {
-    if (!city_view_is_sidebar_collapsed()) {
-        int x_offset = sidebar_common_get_x_offset_expanded();
-        widget_minimap_draw(x_offset + 8, y_offset, 73, 111, force);
-    }
+    return screen_height() - TOP_MENU_HEIGHT;
 }
 
 void sidebar_common_draw_relief(int x_offset, int y_offset, int image, int is_collapsed)

--- a/src/widget/sidebar/common.h
+++ b/src/widget/sidebar/common.h
@@ -7,12 +7,14 @@
 #define SIDEBAR_EXPANDED_WIDTH 162
 #define SIDEBAR_MAIN_SECTION_HEIGHT 450
 #define SIDEBAR_FILLER_Y_OFFSET (SIDEBAR_MAIN_SECTION_HEIGHT + TOP_MENU_HEIGHT)
+#define MINIMAP_WIDTH 73
+#define MINIMAP_HEIGHT 111
 
 int sidebar_common_get_x_offset_expanded(void);
 
 int sidebar_common_get_x_offset_collapsed(void);
 
-void sidebar_common_draw_minimap(int y_offset, int force);
+int sidebar_common_get_height(void);
 
 void sidebar_common_draw_relief(int x_offset, int y_offset, int image, int is_collapsed);
 

--- a/src/widget/sidebar/editor.c
+++ b/src/widget/sidebar/editor.c
@@ -137,7 +137,7 @@ void widget_sidebar_editor_draw_background(void)
     int x_offset = sidebar_common_get_x_offset_expanded();
     image_draw(image_base, x_offset, TOP_MENU_HEIGHT);
     draw_buttons();
-    sidebar_common_draw_minimap(MINIMAP_Y_OFFSET, 1);
+    widget_minimap_draw(x_offset + 8, MINIMAP_Y_OFFSET, MINIMAP_WIDTH, MINIMAP_HEIGHT, 1);
     draw_status();
     sidebar_common_draw_relief(x_offset, SIDEBAR_FILLER_Y_OFFSET, GROUP_EDITOR_SIDE_PANEL, 0);
 }
@@ -145,7 +145,7 @@ void widget_sidebar_editor_draw_background(void)
 void widget_sidebar_editor_draw_foreground(void)
 {
     draw_buttons();
-    sidebar_common_draw_minimap(MINIMAP_Y_OFFSET, 0);
+    widget_minimap_draw(sidebar_common_get_x_offset_expanded() + 8, MINIMAP_Y_OFFSET, MINIMAP_WIDTH, MINIMAP_HEIGHT, 0);
 }
 
 int widget_sidebar_editor_handle_mouse(const mouse *m)

--- a/src/widget/sidebar/slide.c
+++ b/src/widget/sidebar/slide.c
@@ -1,0 +1,84 @@
+#include "slide.h"
+
+#include "city/view.h"
+#include "core/time.h"
+#include "graphics/graphics.h"
+#include "graphics/menu.h"
+#include "graphics/window.h"
+#include "sound/effect.h"
+#include "widget/sidebar/common.h"
+#include "window/city.h"
+
+#define SIDEBAR_SLIDE_STEPS 94
+
+// sliding sidebar progress to x offset translation
+static const int PROGRESS_TO_X_OFFSET[SIDEBAR_SLIDE_STEPS] = {
+    1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 24, 25,
+    27, 28, 30, 31, 33, 35, 37, 39, 41, 43, 45, 47, 49,
+    51, 54, 56, 59, 61, 64, 67, 70, 73, 76, 80, 83, 87,
+    91, 95, 99, 102, 106, 109, 113, 116, 119, 122, 125,
+    127, 130, 132, 135, 137, 139, 141, 143, 144, 146,
+    147, 149, 150, 152, 153, 154, 155, 156, 157, 158,
+    159, 160, 161, 162, 163, 164, 165
+};
+
+static struct {
+    time_millis slide_start;
+    int progress;
+    collapsed_draw_function collapsed_callback;
+    expanded_draw_function expanded_callback;
+} data;
+
+static void update_progress(void)
+{
+    time_millis now = time_get_millis();
+    time_millis diff = now - data.slide_start;
+    data.progress = diff / 5;
+}
+
+static void draw_sliding_foreground(void)
+{
+    window_request_refresh();
+    update_progress();
+    if (data.progress >= SIDEBAR_SLIDE_STEPS) {
+        city_view_toggle_sidebar();
+        window_city_show();
+        window_draw(1);
+        return;
+    }
+
+    int height = sidebar_common_get_height();
+    int x_offset = sidebar_common_get_x_offset_expanded();
+    graphics_set_clip_rectangle(x_offset, TOP_MENU_HEIGHT, SIDEBAR_EXPANDED_WIDTH, sidebar_common_get_height());
+
+    if (city_view_is_sidebar_collapsed()) {
+        x_offset += PROGRESS_TO_X_OFFSET[SIDEBAR_SLIDE_STEPS - data.progress];
+    } else {
+        x_offset += PROGRESS_TO_X_OFFSET[data.progress];
+    }
+
+    data.collapsed_callback();
+    data.expanded_callback(x_offset);
+
+    graphics_reset_clip_rectangle();
+}
+
+void sidebar_slide(collapsed_draw_function collapsed_callback, expanded_draw_function expanded_callback)
+{
+    data.progress = 0;
+    data.slide_start = time_get_millis();
+    data.collapsed_callback = collapsed_callback;
+    data.expanded_callback = expanded_callback;
+    city_view_start_sidebar_toggle();
+    sound_effect_play(SOUND_EFFECT_SIDEBAR);
+
+    window_type window = {
+        WINDOW_SLIDING_SIDEBAR,
+        window_city_draw,
+        draw_sliding_foreground,
+        0,
+        0
+    };
+    window_show(&window);
+}

--- a/src/widget/sidebar/slide.h
+++ b/src/widget/sidebar/slide.h
@@ -1,0 +1,9 @@
+#ifndef WIDGET_SIDEBAR_SLIDE_H
+#define WIDGET_SIDEBAR_SLIDE_H
+
+typedef void (*collapsed_draw_function)(void);
+typedef void (*expanded_draw_function)(int x_offset);
+
+void sidebar_slide(collapsed_draw_function collapsed_callback, expanded_draw_function expanded_callback);
+
+#endif // WIDGET_SIDEBAR_SLIDE_H


### PR DESCRIPTION
* Separate sidebar slide to its own file
* Make the slide use callbacks (useful for the upcoming military sidebar)
* Divide the expanded and collapsed drawing routines to two different functions
* No longer hide some sidebar items while sliding the sidebar

Since the minimap is now cached, displaying it while sliding the sidebar is not that expensive anymore, so we no longer need to cover it in black.