### PR TITLE
Final sidebar slide adjustments

### DIFF
--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -163,7 +163,7 @@ static void run_and_draw(void)
         fps.last_update_time = time_after_draw;
         fps.frame_count = 0;
     }
-    if (window_is(WINDOW_CITY) || window_is(WINDOW_CITY_MILITARY)) {
+    if (window_is(WINDOW_CITY) || window_is(WINDOW_CITY_MILITARY) || window_is(WINDOW_SLIDING_SIDEBAR)) {
         int y_offset = 24;
         int y_offset_text = y_offset + 5;
         graphics_fill_rect(0, y_offset, 100, 20, COLOR_WHITE);

--- a/src/widget/sidebar/city.c
+++ b/src/widget/sidebar/city.c
@@ -270,6 +270,13 @@ int widget_sidebar_city_get_tooltip_text(void)
     return data.focus_button_for_tooltip;
 }
 
+static void slide_finished(void)
+{
+    city_view_toggle_sidebar();
+    window_city_show();
+    window_draw(1);
+}
+
 static void button_overlay(int param1, int param2)
 {
     window_overlay_menu_show();
@@ -277,7 +284,8 @@ static void button_overlay(int param1, int param2)
 
 static void button_collapse_expand(int param1, int param2)
 {
-    sidebar_slide(draw_collapsed_background, draw_expanded_background);
+    city_view_start_sidebar_toggle();
+    sidebar_slide(!city_view_is_sidebar_collapsed(), draw_collapsed_background, draw_expanded_background, slide_finished);
 }
 
 static void button_build(int submenu, int param2)

--- a/src/widget/sidebar/slide.c
+++ b/src/widget/sidebar/slide.c
@@ -8,8 +8,9 @@
 #include "widget/sidebar/common.h"
 #include "window/city.h"
 
-#define SLIDE_SPEED 10
-#define SLIDE_ACCELERATION_MILLIS 75
+#define SLIDE_SPEED 7
+#define SLIDE_ACCELERATION_MILLIS 65
+#define SIDEBAR_DECELERATION_OFFSET 125
 
 static struct {
     int position;
@@ -34,6 +35,9 @@ static void draw_sliding_foreground(void)
     graphics_set_clip_rectangle(x_offset, TOP_MENU_HEIGHT, SIDEBAR_EXPANDED_WIDTH, sidebar_common_get_height());
 
     if (data.direction == SLIDE_DIRECTION_IN) {
+        if (data.position > SIDEBAR_DECELERATION_OFFSET) {
+            speed_set_target(&data.slide_speed, 1, SLIDE_ACCELERATION_MILLIS, 1);
+        }
         x_offset += SIDEBAR_EXPANDED_WIDTH - data.position;
     } else {
         x_offset += data.position;
@@ -50,7 +54,7 @@ void sidebar_slide(slide_direction direction, back_sidebar_draw_function back_si
     data.direction = direction;
     data.position = 0;
     speed_clear(&data.slide_speed);
-    speed_set_target(&data.slide_speed, SLIDE_SPEED, SLIDE_ACCELERATION_MILLIS);
+    speed_set_target(&data.slide_speed, SLIDE_SPEED, direction == SLIDE_DIRECTION_OUT ? SLIDE_ACCELERATION_MILLIS : SPEED_CHANGE_IMMEDIATE, 1);
     data.back_sidebar_draw = back_sidebar_callback;
     data.front_sidebar_draw = front_sidebar_callback;
     data.finished_callback = finished_callback;

--- a/src/widget/sidebar/slide.h
+++ b/src/widget/sidebar/slide.h
@@ -1,9 +1,15 @@
 #ifndef WIDGET_SIDEBAR_SLIDE_H
 #define WIDGET_SIDEBAR_SLIDE_H
 
-typedef void (*collapsed_draw_function)(void);
-typedef void (*expanded_draw_function)(int x_offset);
+typedef enum {
+    SLIDE_DIRECTION_IN = 0,
+    SLIDE_DIRECTION_OUT = 1
+} slide_direction;
 
-void sidebar_slide(collapsed_draw_function collapsed_callback, expanded_draw_function expanded_callback);
+typedef void (*back_sidebar_draw_function)(void);
+typedef back_sidebar_draw_function slide_finished_function;
+typedef void (*front_sidebar_draw_function)(int x_offset);
+
+void sidebar_slide(slide_direction direction, back_sidebar_draw_function back_sidebar_callback, front_sidebar_draw_function front_sidebar_callback, slide_finished_function finished_callback);
 
 #endif // WIDGET_SIDEBAR_SLIDE_H


### PR DESCRIPTION
* Remove slide dependency on city/view.h, allowing the sidebar to be programatically expanded/collapsed
* Use a speed struct to determine the sliding speed instead of a fixed array. Allows for a much smoother slide (even at 144hz), ~albeit at the cost of a slight difference in the way the slide accelarates/decelerates~ <- This has been fixed
* Change some function names
* Keep fps displaying during the sidebar slide

Please have a look at this one before #378.