### PR TITLE
Various scroll and speed fixes

### DIFF
--- a/src/core/speed.c
+++ b/src/core/speed.c
@@ -76,6 +76,9 @@ int handle_fine_position(speed_type *speed, double delta)
 
 int speed_get_delta(speed_type *speed)
 {
+    if (speed->adjust_for_time && speed->last_speed_check == time_get_millis()) {
+        return 0;
+    }
     double delta;
     time_millis elapsed = time_get_millis() - speed->start_time;
     double desired = speed->desired_speed;

--- a/src/core/speed.c
+++ b/src/core/speed.c
@@ -6,28 +6,47 @@
 
 void speed_clear(speed_type *speed)
 {
-    speed->cumulative_delta = 0;
-    speed->desired_speed = 0;
-    speed->current_speed = 0;
-    speed->speed_difference = 0;
+    speed->cumulative_delta = 0.0;
+    speed->fine_position = 0.0;
+    speed->desired_speed = 0.0;
+    speed->current_speed = 0.0;
+    speed->speed_difference = 0.0;
     speed->start_time = 0;
     speed->total_time = 0;
     speed->last_speed_check = time_get_millis();
 }
 
-void speed_set_target(speed_type *speed, int new_speed, time_millis total_time)
+static double adjust_speed_for_elapsed_time(double delta, int adjust_for_time, time_millis last_time)
 {
+    return adjust_for_time ? (delta / FRAME_TIME) * (time_get_millis() - last_time) : delta;
+}
+
+static double adjust_speed_for_frame_time(double delta, int adjust_for_time, time_millis last_time)
+{
+    return adjust_for_time ? ((delta / (double) (time_get_millis() - last_time)) * FRAME_TIME) : delta;
+}
+
+void speed_set_target(speed_type *speed, double new_speed, time_millis total_time, int adjust_for_time)
+{
+    speed->adjust_for_time = adjust_for_time;
     if (new_speed == speed->desired_speed) {
         return;
     }
     if (total_time == SPEED_CHANGE_IMMEDIATE) {
-        speed_clear(speed);
         speed->desired_speed = new_speed;
         speed->current_speed = new_speed;
+        speed->total_time = total_time;
+        if (!adjust_for_time && time_get_millis() - speed->last_speed_check > 0) {
+            speed->adjusted_current_speed = adjust_speed_for_frame_time(new_speed, 1, speed->last_speed_check);
+        } else {
+            speed->adjusted_current_speed = new_speed;
+        }
         return;
     }
-    speed->cumulative_delta = 0;
-    speed->speed_difference = speed->current_speed - new_speed;
+    speed->cumulative_delta = 0.0;
+    speed->fine_position = 0.0;
+    double base_speed = adjust_for_time ? speed->adjusted_current_speed : speed->current_speed;
+    speed->speed_difference = base_speed - new_speed;
     speed->desired_speed = new_speed;
     speed->start_time = time_get_millis();
     speed->total_time = total_time;
@@ -35,7 +54,7 @@ void speed_set_target(speed_type *speed, int new_speed, time_millis total_time)
 
 void speed_invert(speed_type *speed)
 {
-    speed_set_target(speed, -speed->desired_speed, SPEED_CHANGE_IMMEDIATE);
+    speed_set_target(speed, -speed->desired_speed, SPEED_CHANGE_IMMEDIATE, speed->adjust_for_time);
 }
 
 speed_direction speed_get_current_direction(const speed_type *speed)
@@ -46,36 +65,40 @@ speed_direction speed_get_current_direction(const speed_type *speed)
     return (speed->current_speed > 0) ? SPEED_DIRECTION_POSITIVE : SPEED_DIRECTION_NEGATIVE;
 }
 
-static double adjust_speed_for_elapsed_time(int delta, time_millis last_time)
+int handle_fine_position(speed_type *speed, double delta)
 {
-    return round((delta / FRAME_TIME) * (time_get_millis() - last_time));
-}
-
-static int adjust_speed_for_frame_time(double delta, time_millis last_time)
-{
-    return lround((delta / (double) (time_get_millis() - last_time)) * FRAME_TIME);
+    int delta_rounded = (int) delta;
+    speed->fine_position += delta - delta_rounded;
+    int extra_position = (int) speed->fine_position;
+    speed->fine_position -= extra_position;
+    return delta_rounded + extra_position;
 }
 
 int speed_get_delta(speed_type *speed)
 {
     double delta;
     time_millis elapsed = time_get_millis() - speed->start_time;
-    double desired = adjust_speed_for_elapsed_time(speed->desired_speed, speed->last_speed_check);
-    if (speed->current_speed == speed->desired_speed || elapsed > speed->total_time * 4) {
-        delta = (speed->total_time == SPEED_CHANGE_IMMEDIATE) ? speed->desired_speed : desired;
+    double desired = speed->desired_speed;
+    desired = adjust_speed_for_elapsed_time(speed->desired_speed, speed->adjust_for_time, speed->last_speed_check);
+    if (speed->total_time == SPEED_CHANGE_IMMEDIATE) {
+        delta = desired;
+    } else if (speed->current_speed == speed->desired_speed || elapsed > speed->total_time * 4) {
+        delta = desired;
         speed->current_speed = speed->desired_speed;
+        speed->adjusted_current_speed = speed->desired_speed;
     } else {
         if (elapsed == 0) {
-            delta = adjust_speed_for_elapsed_time(speed->current_speed, speed->last_speed_check);
+            delta = adjust_speed_for_elapsed_time(speed->current_speed, speed->adjust_for_time, speed->last_speed_check);
         } else {
-            double normalized_speed = speed->speed_difference * (speed->total_time / FRAME_TIME);
+            double full_delta = speed->speed_difference * (speed->total_time / FRAME_TIME);
             double exponent = exp(-((int) elapsed) / (double) speed->total_time);
-            delta = normalized_speed - normalized_speed * exponent - speed->cumulative_delta;
-            speed->cumulative_delta += (int) delta;
-            delta = desired + delta;
-            speed->current_speed = adjust_speed_for_frame_time(delta, speed->last_speed_check);
+            delta = full_delta - full_delta * exponent - speed->cumulative_delta;
+            speed->cumulative_delta += delta;
+            delta += desired;
+            speed->current_speed = adjust_speed_for_frame_time(delta, speed->adjust_for_time, speed->last_speed_check);
+            speed->adjusted_current_speed = speed->current_speed;
         }
     }
     speed->last_speed_check = time_get_millis();
-    return (int) delta;
+    return handle_fine_position(speed, delta);
 }

--- a/src/core/speed.c
+++ b/src/core/speed.c
@@ -54,7 +54,7 @@ void speed_set_target(speed_type *speed, double new_speed, time_millis total_tim
 
 void speed_invert(speed_type *speed)
 {
-    speed_set_target(speed, -speed->desired_speed, SPEED_CHANGE_IMMEDIATE, speed->adjust_for_time);
+    speed_set_target(speed, -speed->current_speed, SPEED_CHANGE_IMMEDIATE, speed->adjust_for_time);
 }
 
 speed_direction speed_get_current_direction(const speed_type *speed)

--- a/src/core/speed.h
+++ b/src/core/speed.h
@@ -65,6 +65,7 @@ void speed_invert(speed_type *speed);
  * Gets the delta, in pixels, to move since the last time speed_get_delta was called
  * If speed_should_adjust_for_elapsed_time is enabled, the delta value is adjust_for_time to keep
  * the same rate regardless of FPS
+ * Please note: this function should only be called once per frame
  * @param speed Speed structure to act on
  * @return The delta movement
  */

--- a/src/core/speed.h
+++ b/src/core/speed.h
@@ -28,10 +28,13 @@ typedef struct {
     time_millis start_time;
     time_millis total_time;
     time_millis last_speed_check;
-    int speed_difference;
-    int desired_speed;
-    int current_speed;
-    int cumulative_delta;
+    double speed_difference;
+    double desired_speed;
+    double current_speed;
+    double adjusted_current_speed;
+    double cumulative_delta;
+    double fine_position;
+    int adjust_for_time;
 } speed_type;
 
 /**
@@ -45,8 +48,12 @@ void speed_clear(speed_type *speed);
  * @param speed Speed structure to act on
  * @param new_speed The new speed
  * @param total_time the time for the acceleration/deceleration, or SPEED_CHANGE_IMMEDIATE
+ * @param adjust_for_time If set to "1", in speed_get_delta, the delta value will be
+ *                        adjusted to keep the same rate regardless of FPS
+ *                        If set to "0", speed_get_delta will return the brute value
+ *                        without taking into account the elapsed time
  */
-void speed_set_target(speed_type *speed, int new_speed, time_millis total_time);
+void speed_set_target(speed_type *speed, double new_speed, time_millis total_time, int adjust_for_time);
 
 /**
  * Immediately invert the speed (positive speed becomes negative and vice-versa)
@@ -56,8 +63,8 @@ void speed_invert(speed_type *speed);
 
 /**
  * Gets the delta, in pixels, to move since the last time speed_get_delta was called
- * The delta value is normalized to keep the same rate regardless of FPS, EXCEPT if
- * SPEED_CHANGE_IMMEDIATE was passed in speed_set_target
+ * If speed_should_adjust_for_elapsed_time is enabled, the delta value is adjust_for_time to keep
+ * the same rate regardless of FPS
  * @param speed Speed structure to act on
  * @return The delta movement
  */

--- a/src/graphics/window.c
+++ b/src/graphics/window.c
@@ -3,6 +3,7 @@
 #include "graphics/warning.h"
 #include "input/cursor.h"
 #include "input/hotkey.h"
+#include "input/scroll.h"
 #include "input/touch.h"
 #include "window/city.h"
 
@@ -40,6 +41,13 @@ static void decrease_queue_index(void)
     }
 }
 
+static void reset_input(void)
+{
+    mouse_reset_button_state();
+    reset_touches(1);
+    scroll_stop();
+}
+
 void window_invalidate(void)
 {
     data.refresh_immediate = 1;
@@ -68,8 +76,7 @@ window_id window_get_id(void)
 
 void window_show(const window_type *window)
 {
-    mouse_reset_button_state();
-    reset_touches(1);
+    reset_input();
     increase_queue_index();
     data.window_queue[data.queue_index] = *window;
     data.current_window = &data.window_queue[data.queue_index];
@@ -87,6 +94,7 @@ void window_show(const window_type *window)
 
 void window_go_back(void)
 {
+    reset_input();
     decrease_queue_index();
     data.current_window = &data.window_queue[data.queue_index];
     window_invalidate();

--- a/src/input/scroll.c
+++ b/src/input/scroll.c
@@ -489,6 +489,7 @@ int scroll_get_delta(const mouse *m, pixel_offset *delta, scroll_type type)
 void scroll_stop(void)
 {
     clear_scroll_speed();
+    system_mouse_set_relative_mode(0);
     data.is_scrolling = 0;
     data.constant_input = 0;
     data.drag.active = 0;

--- a/src/input/scroll.c
+++ b/src/input/scroll.c
@@ -281,8 +281,8 @@ static int set_scroll_speed_from_drag(void)
         }
     }
     if (data.drag.has_started) {
-        speed_set_target(&data.speed.x, data.drag.delta.x, SPEED_CHANGE_IMMEDIATE);
-        speed_set_target(&data.speed.y, data.drag.delta.y, SPEED_CHANGE_IMMEDIATE);
+        speed_set_target(&data.speed.x, data.drag.delta.x, SPEED_CHANGE_IMMEDIATE, 0);
+        speed_set_target(&data.speed.y, data.drag.delta.y, SPEED_CHANGE_IMMEDIATE, 0);
         data.drag.delta.x = 0;
         data.drag.delta.y = 0;
     }
@@ -304,13 +304,13 @@ int scroll_drag_end(void)
         system_mouse_set_relative_mode(0);
     } else if (has_scrolled) {
         const touch *t = get_earliest_touch();
-        speed_set_target(&data.speed.x, -t->frame_movement.x, SPEED_CHANGE_IMMEDIATE);
-        speed_set_target(&data.speed.y, -t->frame_movement.y, SPEED_CHANGE_IMMEDIATE);
+        speed_set_target(&data.speed.x, -t->frame_movement.x, SPEED_CHANGE_IMMEDIATE, 1);
+        speed_set_target(&data.speed.y, -t->frame_movement.y, SPEED_CHANGE_IMMEDIATE, 1);
     }
     data.x_align_direction = speed_get_current_direction(&data.speed.x);
     data.y_align_direction = speed_get_current_direction(&data.speed.y);
-    speed_set_target(&data.speed.x, 0, SCROLL_DRAG_DECAY_TIME);
-    speed_set_target(&data.speed.y, 0, SCROLL_DRAG_DECAY_TIME);
+    speed_set_target(&data.speed.x, 0, SCROLL_DRAG_DECAY_TIME, 1);
+    speed_set_target(&data.speed.y, 0, SCROLL_DRAG_DECAY_TIME, 1);
 
     return has_scrolled;
 }
@@ -425,8 +425,8 @@ static int set_scroll_speed_from_input(const mouse *m, scroll_type type)
     int direction = get_direction(m);
     if (direction == DIR_8_NONE) {
         time_millis time = config_get(CONFIG_UI_SMOOTH_SCROLLING) ? SCROLL_REGULAR_DECAY_TIME : SPEED_CHANGE_IMMEDIATE;
-        speed_set_target(&data.speed.x, 0, time);
-        speed_set_target(&data.speed.y, 0, time);
+        speed_set_target(&data.speed.x, 0, time, 1);
+        speed_set_target(&data.speed.y, 0, time, 1);
         return 0;
     }
     if (data.speed.decaying) {
@@ -447,8 +447,8 @@ static int set_scroll_speed_from_input(const mouse *m, scroll_type type)
             align_x = get_alignment_delta(dir_x, TILE_X_PIXELS, camera_offset.x);
             align_y = get_alignment_delta(dir_y, TILE_Y_PIXELS, camera_offset.y);
         }
-        speed_set_target(&data.speed.x, (step + align_x) * dir_x * do_scroll, SPEED_CHANGE_IMMEDIATE);
-        speed_set_target(&data.speed.y, ((step / y_fraction) + align_y) * dir_y * do_scroll, SPEED_CHANGE_IMMEDIATE);
+        speed_set_target(&data.speed.x, (step + align_x) * dir_x * do_scroll, SPEED_CHANGE_IMMEDIATE, 0);
+        speed_set_target(&data.speed.y, ((step / y_fraction) + align_y) * dir_y * do_scroll, SPEED_CHANGE_IMMEDIATE, 0);
         return 1;
     }
 
@@ -460,16 +460,16 @@ static int set_scroll_speed_from_input(const mouse *m, scroll_type type)
         if (speed_get_current_direction(&data.speed.x) * dir_x < 0) {
             speed_invert(&data.speed.x);
         } else if (data.speed.x.desired_speed != max_speed_x) {
-            speed_set_target(&data.speed.x, max_speed_x, SCROLL_REGULAR_DECAY_TIME);
+            speed_set_target(&data.speed.x, max_speed_x, SCROLL_REGULAR_DECAY_TIME, 1);
         }
         if (speed_get_current_direction(&data.speed.y) * dir_y < 0) {
             speed_invert(&data.speed.y);
         } else if (data.speed.y.desired_speed != max_speed_y) {
-            speed_set_target(&data.speed.y, max_speed_y, SCROLL_REGULAR_DECAY_TIME);
+            speed_set_target(&data.speed.y, max_speed_y, SCROLL_REGULAR_DECAY_TIME, 1);
         }
     } else {
-        speed_set_target(&data.speed.x, (int) (max_speed_x * data.speed.modifier_x), SPEED_CHANGE_IMMEDIATE);
-        speed_set_target(&data.speed.y, (int) (max_speed_y * data.speed.modifier_y), SPEED_CHANGE_IMMEDIATE);
+        speed_set_target(&data.speed.x, (int) (max_speed_x * data.speed.modifier_x), SPEED_CHANGE_IMMEDIATE, 1);
+        speed_set_target(&data.speed.y, (int) (max_speed_y * data.speed.modifier_y), SPEED_CHANGE_IMMEDIATE, 1);
     }
     return 1;
 }
@@ -484,6 +484,15 @@ int scroll_get_delta(const mouse *m, pixel_offset *delta, scroll_type type)
         data.is_scrolling = data.speed.decaying;
     }
     return delta->x != 0 || delta->y != 0;
+}
+
+void scroll_stop(void)
+{
+    clear_scroll_speed();
+    data.is_scrolling = 0;
+    data.constant_input = 0;
+    data.drag.active = 0;
+    data.limits.active = 0;
 }
 
 void scroll_arrow_left(int value)

--- a/src/input/scroll.h
+++ b/src/input/scroll.h
@@ -22,6 +22,8 @@ int scroll_get_delta(const mouse *m, pixel_offset *delta, scroll_type type);
 void scroll_drag_start(int is_touch);
 int scroll_drag_end(void);
 
+void scroll_stop(void);
+
 void scroll_arrow_left(int value);
 void scroll_arrow_right(int value);
 void scroll_arrow_up(int value);


### PR DESCRIPTION
Fix scroll issues on slower/faster FPS

So it turns out the speed structure designed to allow fps-independent scrolling wasn't doing its job properly at all:

* On low FPS, the scroll decay was way too fast
* On high FPS, keyboard scrolling didn't work at all and using the sidebar with the speed struct almost softlocked the game

This PR fixes both bugs. Also, it adds proper subpixel precision, making diagonal scrolling absolutely proportional again.

Also, cancel scrolling when a new window is opened. Prevents scrolling from going haywire when that window is closed.