### PR TITLE
Prevent aqueduct ghost from appearing on curved roads

### DIFF
--- a/src/map/road_aqueduct.c
+++ b/src/map/road_aqueduct.c
@@ -137,15 +137,19 @@ static int get_road_tile_for_aqueduct(int grid_offset, int gate_orientation)
 
 int map_get_adjacent_road_tiles_for_aqueduct(int grid_offset)
 {
-    int road_tiles = 0;
-    road_tiles += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(0, -1), 1);
-    road_tiles += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(1, 0), 2);
-    road_tiles += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(0, 1), 1);
-    road_tiles += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(-1, 0), 2);
+    int road_tiles_x = 0;
+    int road_tiles_y = 0;
+    road_tiles_y += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(0, -1), 1);
+    road_tiles_x += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(1, 0), 2);
+    road_tiles_y += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(0, 1), 1);
+    road_tiles_x += get_road_tile_for_aqueduct(grid_offset + map_grid_delta(-1, 0), 2);
+    int road_tiles = road_tiles_x + road_tiles_y;
     if (road_tiles == 4) {
         if (building_get(map_building_at(grid_offset))->type == BUILDING_GRANARY) {
-            road_tiles = 2;
+            return 2;
         }
+    } else if (road_tiles_x == 1 && road_tiles_y == 1) { // Curved roads
+        return 0;
     }
     return road_tiles;
 }


### PR DESCRIPTION
These can't be constructed, so the ghost shouldn't appear.

Before:

![city 2020-05-26 14 33 30](https://user-images.githubusercontent.com/6518876/82907390-76f91900-9f5e-11ea-869a-6e35412d6941.png)

After:

![city 2020-05-26 14 34 17](https://user-images.githubusercontent.com/6518876/82907414-7f515400-9f5e-11ea-9ade-1baf6e1982d5.png)