### PR TITLE
Make game speed independent of fps

### DIFF
--- a/src/game/file.c
+++ b/src/game/file.c
@@ -96,7 +96,7 @@ static void clear_scenario_data(void)
     building_construction_clear_type();
     city_data_init();
     city_message_init_scenario();
-    game_state_init();
+    game_state_init(setting_game_speed());
     game_animation_init();
     sound_city_init();
     building_menu_enable_all();
@@ -238,6 +238,8 @@ static void initialize_saved_game(void)
     map_tiles_determine_gardens();
 
     city_message_clear_scroll();
+
+    game_state_set_speed(setting_game_speed(), 1);
 
     game_state_unpause();
 }

--- a/src/game/file_editor.c
+++ b/src/game/file_editor.c
@@ -55,7 +55,7 @@ void game_file_editor_clear_data(void)
     city_data_init();
     city_data_init_scenario();
     city_message_init_scenario();
-    game_state_init();
+    game_state_init(70); // speed at 70%, nice speed for flag animations
     game_animation_init();
     sound_city_init();
     building_menu_enable_all();

--- a/src/game/state.c
+++ b/src/game/state.c
@@ -3,19 +3,27 @@
 #include "city/victory.h"
 #include "city/view.h"
 #include "city/warning.h"
+#include "core/speed.h"
 #include "core/random.h"
 #include "map/ring.h"
+
+#include <math.h>
 
 static struct {
     int paused;
     int current_overlay;
     int previous_overlay;
-} data = {0, OVERLAY_NONE, OVERLAY_NONE};
+    speed_type game_speed;
+} data;
 
-void game_state_init(void)
+#define GAME_SPEED_MULTIPLIER 1.46
+
+void game_state_init(int speed)
 {
     city_victory_reset();
     map_ring_init();
+
+    game_state_set_speed(speed, 1);
 
     city_view_reset_orientation();
     city_view_set_camera(76, 152);
@@ -38,6 +46,22 @@ void game_state_unpause(void)
 void game_state_toggle_paused(void)
 {
     data.paused = data.paused ? 0 : 1;
+}
+
+void game_state_set_speed(int speed, int adjust_for_time)
+{
+    int game_speed_index = (100 - speed) / 10;
+    if (game_speed_index >= 10) {
+        game_speed_index = 9;
+    } else if (game_speed_index < 0) {
+        game_speed_index /= 10;
+    }
+    speed_set_target(&data.game_speed, pow(GAME_SPEED_MULTIPLIER, -game_speed_index), SPEED_CHANGE_IMMEDIATE, adjust_for_time);
+}
+
+int game_state_get_ticks(void)
+{
+    return speed_get_delta(&data.game_speed);
 }
 
 int game_state_overlay(void)

--- a/src/game/state.h
+++ b/src/game/state.h
@@ -29,13 +29,17 @@ enum {
     OVERLAY_PROBLEMS = 29
 };
 
-void game_state_init(void);
+void game_state_init(int speed);
 
 int game_state_is_paused(void);
 
 void game_state_toggle_paused(void);
 
 void game_state_unpause(void);
+
+void game_state_set_speed(int speed, int adjust_for_time);
+
+int game_state_get_ticks(void);
 
 int game_state_overlay(void);
 

--- a/src/widget/sidebar/extra.c
+++ b/src/widget/sidebar/extra.c
@@ -7,6 +7,7 @@
 #include "core/lang.h"
 #include "core/string.h"
 #include "game/settings.h"
+#include "game/state.h"
 #include "graphics/arrow_button.h"
 #include "graphics/graphics.h"
 #include "graphics/lang_text.h"
@@ -277,4 +278,5 @@ static void button_game_speed(int is_down, int param2)
     } else {
         setting_increase_game_speed();
     }
+    game_state_set_speed(setting_game_speed(), 1);
 }

--- a/src/window/city.c
+++ b/src/window/city.c
@@ -167,9 +167,11 @@ static void handle_hotkeys(const hotkeys *h)
     }
     if (h->decrease_game_speed) {
         setting_decrease_game_speed();
+        game_state_set_speed(setting_game_speed(), 1);
     }
     if (h->increase_game_speed) {
         setting_increase_game_speed();
+        game_state_set_speed(setting_game_speed(), 1);
     }
     if (h->show_overlay) {
         show_overlay(h->show_overlay);

--- a/src/window/speed_options.c
+++ b/src/window/speed_options.c
@@ -1,6 +1,7 @@
 #include "speed_options.h"
 
 #include "game/settings.h"
+#include "game/state.h"
 #include "graphics/arrow_button.h"
 #include "graphics/generic_button.h"
 #include "graphics/graphics.h"
@@ -89,6 +90,7 @@ static void button_ok(int param1, int param2)
 static void button_cancel(int param1, int param2)
 {
     setting_reset_speeds(data.original_game_speed, data.original_scroll_speed);
+    game_state_set_speed(data.original_game_speed, 1);
     data.close_callback();
 }
 
@@ -99,6 +101,7 @@ static void arrow_button_game(int is_down, int param2)
     } else {
         setting_increase_game_speed();
     }
+    game_state_set_speed(setting_game_speed(), 1);
 }
 
 static void arrow_button_scroll(int is_down, int param2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,6 @@ endfunction(except_file)
 # Replace some source files with stubs
 except_file(TEST_CORE_FILES "core/image.c" ${CORE_FILES})
 except_file(TEST_CORE_FILES "core/lang.c" ${TEST_CORE_FILES})
-except_file(TEST_CORE_FILES "core/speed.c" ${TEST_CORE_FILES})
 except_file(TEST_BUILDING_FILES "building/model.c" ${BUILDING_FILES})
 
 add_executable(compare
@@ -52,6 +51,10 @@ add_executable(autopilot
     ${SOUND_FILES}
     ${EDITOR_FILES}
 )
+
+if (UNIX AND NOT APPLE AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang"))
+    target_link_libraries(autopilot m)
+endif()
 
 file(COPY data/c3.emp DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY data/c32.emp DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/sav/run.c
+++ b/test/sav/run.c
@@ -3,6 +3,7 @@
 #include "game/file.h"
 #include "game/game.h"
 #include "game/settings.h"
+#include "game/state.h"
 
 #ifdef _MSC_VER
 #include <direct.h>
@@ -26,7 +27,7 @@ static void handler(int sig)
 
 static void run_ticks(int ticks)
 {
-    setting_reset_speeds(100, setting_scroll_speed());
+    game_state_set_speed(100, 0);
     time_set_millis(0);
     for (int i = 1; i <= ticks; i++) {
         time_set_millis(2 * i);


### PR DESCRIPTION
Before, at speeds at or above 100%, the game played at 1 (or 2 at 200%, 3 at 300%, etc...) in-game ticks per frame. This caused 100% game speed to be much faster on 144hz monitors and slower when fps was low.

This PR fixes that, and now the game always runs at the same speed regardless of fps, with a maximum limit of 20 ticks per frame.

This also effectively frameskips when fps is low, mantaining the in-game speed consistent.

There are some slight differences in speed, that aren't really noticeable on speeds below 100% but are palpable in the 200% and 300% game speeds (for the old code, the speeds are based on a 60fps framerate):

```
         |  MS per tick - avg
   Game  |--------------------
  speed  | Old code | New code
------------------------------
   10%   | 502.00   | 502.47
   20%   | 352.00   | 344.15
   30%   | 242.00   | 235.72
   40%   | 162.00   | 161.45
   50%   | 112.00   | 110.58
   60%   |  82.00   |  75.74
   70%   |  57.00   |  51.87
   80%   |  37.00   |  35.53
   90%   |  22.00   |  24.33
  100%   |  16.67   |  16.67
  200%   |   8.33   |  11.41
  300%   |   5.55   |   7.82
  400%   |   4.16   |   5.35
  500%   |   3.33   |   3.66
```