### PR TITLE
Fix combat music being swapped

### DIFF
--- a/src/sound/music.c
+++ b/src/sound/music.c
@@ -31,8 +31,8 @@ static const char tracks[][32] = {
     "wavs/ROME3.WAV",
     "wavs/ROME4.WAV",
     "wavs/ROME5.WAV",
-    "wavs/Combat_Long.wav",
     "wavs/Combat_Short.wav",
+    "wavs/Combat_Long.wav",
     "wavs/setup.wav"
 };
 
@@ -43,8 +43,8 @@ static const char mp3_tracks[][32] = {
     "mp3/ROME3.mp3",
     "mp3/ROME4.mp3",
     "mp3/ROME5.mp3",
-    "mp3/Combat_Long.mp3",
     "mp3/Combat_Short.mp3",
+    "mp3/Combat_Long.mp3",
     "mp3/setup.mp3"
 };
 


### PR DESCRIPTION
Right now music track constants point to the wrong track names, resulting in combat_short and combat_long tracks playing when the other one should be played. This fixes #487.