### PR TITLE
Change smooth scrolling default to enabled

### DIFF
--- a/src/core/config.c
+++ b/src/core/config.c
@@ -32,7 +32,7 @@ static const char *ini_string_keys[] = {
 static int values[CONFIG_MAX_ENTRIES];
 static char string_values[CONFIG_STRING_MAX_ENTRIES][CONFIG_STRING_VALUE_MAX];
 
-static int default_values[CONFIG_MAX_ENTRIES];
+static int default_values[CONFIG_MAX_ENTRIES] = {[CONFIG_UI_SMOOTH_SCROLLING] = 1};
 static const char default_string_values[CONFIG_STRING_MAX_ENTRIES][CONFIG_STRING_VALUE_MAX];
 
 int config_get(config_key key)


### PR DESCRIPTION
Smooth scrolling is not a gameplay change so I think that it's worth enabling by default.