### PR TITLE
Switch build: revert to docker, but use official devkitpro image

### DIFF
--- a/.ci_scripts/run_build.sh
+++ b/.ci_scripts/run_build.sh
@@ -5,9 +5,7 @@ case "$BUILD_TARGET" in
 	docker exec vitasdk /bin/bash -c "cd build && make"
 	;;
 "switch")
-	export DEVKITPRO=/opt/devkitpro
-	export PATH=/opt/devkitpro/devkitA64/bin:/opt/devkitpro/tools/bin:$PATH
-	cd build && make
+	docker exec switchdev /bin/bash -c "cd build && make"
 	;;
 "mac")
 	cd build && make && make test && make install && \

--- a/.ci_scripts/run_cmake.sh
+++ b/.ci_scripts/run_cmake.sh
@@ -5,9 +5,7 @@ case "$BUILD_TARGET" in
 	docker exec vitasdk /bin/bash -c "mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DVITA_BUILD=ON .."
 	;;
 "switch")
-	export DEVKITPRO=/opt/devkitpro
-	export PATH=/opt/devkitpro/devkitA64/bin:/opt/devkitpro/tools/bin:$PATH
-	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSWITCH_BUILD=ON ..
+	docker exec switchdev /bin/bash -c "mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSWITCH_BUILD=ON .."
 	;;
 "mac")
 	mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DSYSTEM_LIBS=OFF ..

--- a/.ci_scripts/setup_environment.sh
+++ b/.ci_scripts/setup_environment.sh
@@ -8,8 +8,7 @@ case "$BUILD_TARGET" in
 	docker run -d --name vitasdk --workdir /build/git -v "${PWD}:/build/git" gnuton/vitasdk-docker:20190626 tail -f /dev/null
 	;;
 "switch")
-	wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb
-	sudo dpkg -i devkitpro-pacman.deb
-	sudo dkp-pacman -Syyu --noconfirm devkitA64 devkitpro-pkgbuild-helpers libnx switch-tools switch-pkg-config switch-sdl2 switch-sdl2_mixer switch-libpng
+	docker run -d --name switchdev --workdir /build/git -v "${PWD}:/build/git" devkitpro/devkita64:20200528 tail -f /dev/null
+	docker exec switchdev /bin/bash -c "apt-get update && apt-get install -y --no-install-recommends cmake"
 	;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ jobs:
       - docker
   - os: linux
     name: Nintendo Switch
+    services:
+      - docker
     env: BUILD_TARGET=switch DEPLOY=switch
 
 cache:

--- a/cmake/switch.cmake
+++ b/cmake/switch.cmake
@@ -1,4 +1,27 @@
-include($ENV{DEVKITPRO}/devkita64.cmake)
+cmake_minimum_required(VERSION 3.2)
+
+set(DEVKITPRO $ENV{DEVKITPRO})
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "aarch64")
+set(CMAKE_CROSSCOMPILING 1)
+
+set(TOOL_PREFIX ${DEVKITPRO}/devkitA64/bin/aarch64-none-elf-)
+
+set(CMAKE_ASM_COMPILER ${TOOL_PREFIX}gcc    CACHE PATH "")
+set(CMAKE_C_COMPILER   ${TOOL_PREFIX}gcc    CACHE PATH "")
+set(CMAKE_CXX_COMPILER ${TOOL_PREFIX}g++    CACHE PATH "")
+set(CMAKE_LINKER       ${TOOL_PREFIX}g++    CACHE PATH "")
+set(CMAKE_AR           ${TOOL_PREFIX}ar     CACHE PATH "")
+set(CMAKE_STRIP        ${TOOL_PREFIX}strip  CACHE PATH "")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+SET(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Shared libs not available" )
 
 set (DKA_SWITCH_C_FLAGS "-D__SWITCH__ -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -ftls-model=local-exec -fPIE -ffunction-sections -fdata-sections  -L${DEVKITPRO}/portlibs/switch/lib -L${DEVKITPRO}/libnx/lib -specs=${DEVKITPRO}/libnx/switch.specs")
 set(CMAKE_C_FLAGS   "${DKA_SWITCH_C_FLAGS}" CACHE STRING "")


### PR DESCRIPTION
Using a stable image and not the latest one too. This should (hopefully) be more stable than relying on installing devkitpro.