### PR TITLE
Improvements to menu handling

### DIFF
--- a/src/widget/sidebar/city.c
+++ b/src/widget/sidebar/city.c
@@ -293,22 +293,26 @@ static void button_build(int submenu, int param2)
 
 static void button_undo(int param1, int param2)
 {
+    window_build_menu_show(SUBMENU_NONE);
     game_undo_perform();
     window_invalidate();
 }
 
 static void button_messages(int param1, int param2)
 {
+    window_build_menu_show(SUBMENU_NONE);
     window_message_list_show();
 }
 
 static void button_help(int param1, int param2)
 {
+    window_build_menu_show(SUBMENU_NONE);
     window_message_dialog_show(param2, window_city_draw_all);
 }
 
 static void button_go_to_problem(int param1, int param2)
 {
+    window_build_menu_show(SUBMENU_NONE);
     int grid_offset = city_message_next_problem_area_grid_offset();
     if (grid_offset) {
         city_view_go_to_grid_offset(grid_offset);

--- a/src/widget/sidebar/city.c
+++ b/src/widget/sidebar/city.c
@@ -293,26 +293,26 @@ static void button_build(int submenu, int param2)
 
 static void button_undo(int param1, int param2)
 {
-    window_build_menu_show(SUBMENU_NONE);
+    window_build_menu_hide();
     game_undo_perform();
     window_invalidate();
 }
 
 static void button_messages(int param1, int param2)
 {
-    window_build_menu_show(SUBMENU_NONE);
+    window_build_menu_hide();
     window_message_list_show();
 }
 
 static void button_help(int param1, int param2)
 {
-    window_build_menu_show(SUBMENU_NONE);
+    window_build_menu_hide();
     window_message_dialog_show(param2, window_city_draw_all);
 }
 
 static void button_go_to_problem(int param1, int param2)
 {
-    window_build_menu_show(SUBMENU_NONE);
+    window_build_menu_hide();
     int grid_offset = city_message_next_problem_area_grid_offset();
     if (grid_offset) {
         city_view_go_to_grid_offset(grid_offset);

--- a/src/widget/sidebar/editor.c
+++ b/src/widget/sidebar/editor.c
@@ -169,6 +169,7 @@ int widget_sidebar_editor_handle_mouse_attributes(const mouse *m)
 
 static void button_attributes(int show, int param2)
 {
+    window_editor_build_menu_show(MENU_NONE);
     if (show) {
         if (!window_is(WINDOW_EDITOR_ATTRIBUTES)) {
             window_editor_attributes_show();
@@ -182,6 +183,7 @@ static void button_attributes(int show, int param2)
 
 static void button_build_tool(int tool, int param2)
 {
+    window_editor_build_menu_show(MENU_NONE);
     widget_map_editor_clear_current_tile();
     editor_tool_set_type(tool);
     if (window_is(WINDOW_EDITOR_BUILD_MENU)) {

--- a/src/widget/sidebar/editor.c
+++ b/src/widget/sidebar/editor.c
@@ -169,7 +169,7 @@ int widget_sidebar_editor_handle_mouse_attributes(const mouse *m)
 
 static void button_attributes(int show, int param2)
 {
-    window_editor_build_menu_show(MENU_NONE);
+    window_editor_build_menu_hide();
     if (show) {
         if (!window_is(WINDOW_EDITOR_ATTRIBUTES)) {
             window_editor_attributes_show();
@@ -183,7 +183,7 @@ static void button_attributes(int show, int param2)
 
 static void button_build_tool(int tool, int param2)
 {
-    window_editor_build_menu_show(MENU_NONE);
+    window_editor_build_menu_hide();
     widget_map_editor_clear_current_tile();
     editor_tool_set_type(tool);
     if (window_is(WINDOW_EDITOR_BUILD_MENU)) {

--- a/src/window/build_menu.c
+++ b/src/window/build_menu.c
@@ -22,6 +22,8 @@
 #define MENU_ITEM_WIDTH 176
 #define MENU_CLICK_MARGIN 20
 
+#define SUBMENU_NONE -1
+
 static void button_menu_index(int param1, int param2);
 static void button_menu_item(int item);
 
@@ -291,8 +293,7 @@ static void button_menu_item(int item)
 void window_build_menu_show(int submenu)
 {
     if (submenu == SUBMENU_NONE || submenu == data.selected_submenu) {
-        data.selected_submenu = SUBMENU_NONE;
-        window_city_show();
+        window_build_menu_hide();
         return;
     }
     if (init(submenu)) {
@@ -305,4 +306,10 @@ void window_build_menu_show(int submenu)
         };
         window_show(&window);
     }
+}
+
+void window_build_menu_hide(void)
+{
+    data.selected_submenu = SUBMENU_NONE;
+    window_city_show();
 }

--- a/src/window/build_menu.c
+++ b/src/window/build_menu.c
@@ -21,7 +21,6 @@
 #define MENU_ITEM_HEIGHT 24
 #define MENU_ITEM_WIDTH 176
 #define MENU_CLICK_MARGIN 20
-#define SUBMENU_NONE -1
 
 static void button_menu_index(int param1, int param2);
 static void button_menu_item(int item);
@@ -291,7 +290,7 @@ static void button_menu_item(int item)
 
 void window_build_menu_show(int submenu)
 {
-    if (submenu == data.selected_submenu) {
+    if (submenu == SUBMENU_NONE || submenu == data.selected_submenu) {
         data.selected_submenu = SUBMENU_NONE;
         window_city_show();
         return;

--- a/src/window/build_menu.h
+++ b/src/window/build_menu.h
@@ -1,10 +1,10 @@
 #ifndef WINDOW_BUILD_MENU_H
 #define WINDOW_BUILD_MENU_H
 
-#define SUBMENU_NONE -1
-
 int window_build_menu_image(void);
 
 void window_build_menu_show(int submenu);
+
+void window_build_menu_hide(void);
 
 #endif // WINDOW_BUILD_MENU_H

--- a/src/window/build_menu.h
+++ b/src/window/build_menu.h
@@ -1,6 +1,8 @@
 #ifndef WINDOW_BUILD_MENU_H
 #define WINDOW_BUILD_MENU_H
 
+#define SUBMENU_NONE -1
+
 int window_build_menu_image(void);
 
 void window_build_menu_show(int submenu);

--- a/src/window/editor/build_menu.c
+++ b/src/window/editor/build_menu.c
@@ -187,8 +187,7 @@ static void button_menu_item(int index, int param2)
 void window_editor_build_menu_show(int submenu)
 {
     if (submenu == MENU_NONE || submenu == data.selected_submenu) {
-        data.selected_submenu = MENU_NONE;
-        window_editor_map_show();
+        window_editor_build_menu_hide();
         return;
     }
     init(submenu);
@@ -199,4 +198,10 @@ void window_editor_build_menu_show(int submenu)
         handle_input
     };
     window_show(&window);
+}
+
+void window_editor_build_menu_hide(void)
+{
+    data.selected_submenu = MENU_NONE;
+    window_editor_map_show();
 }

--- a/src/window/editor/build_menu.c
+++ b/src/window/editor/build_menu.c
@@ -11,6 +11,12 @@
 #include "widget/sidebar/editor.h"
 #include "window/editor/map.h"
 
+#define MENU_X_OFFSET 170
+#define MENU_Y_OFFSET 110
+#define MENU_ITEM_HEIGHT 24
+#define MENU_ITEM_WIDTH 160
+#define MENU_CLICK_MARGIN 20
+
 static void button_menu_item(int index, int param2);
 
 static generic_button build_menu_buttons[] = {
@@ -53,7 +59,7 @@ static struct {
     int y_offset;
 
     int focus_button_id;
-} data;
+} data = { MENU_NONE };
 
 static int count_items(int submenu)
 {
@@ -87,9 +93,11 @@ static void draw_menu_buttons(void)
 {
     int x_offset = get_sidebar_x_offset();
     for (int i = 0; i < data.num_items; i++) {
-        label_draw(x_offset - 170, data.y_offset + 110 + 24 * i, 10, data.focus_button_id == i + 1 ? 1 : 2);
-        lang_text_draw_centered(48, MENU_TYPES[data.selected_submenu][i], x_offset - 170,
-            data.y_offset + 113 + 24 * i, 160, FONT_NORMAL_GREEN);
+        label_draw(x_offset - MENU_X_OFFSET, data.y_offset + MENU_Y_OFFSET + MENU_ITEM_HEIGHT * i, 10,
+            data.focus_button_id == i + 1 ? 1 : 2);
+        lang_text_draw_centered(48, MENU_TYPES[data.selected_submenu][i], x_offset - MENU_X_OFFSET,
+            data.y_offset + MENU_Y_OFFSET + 3 + MENU_ITEM_HEIGHT * i,
+            MENU_ITEM_WIDTH, FONT_NORMAL_GREEN);
     }
 }
 
@@ -99,10 +107,19 @@ static void draw_foreground(void)
     draw_menu_buttons();
 }
 
+static int click_outside_menu(const mouse *m, int x_offset)
+{
+    return m->left.went_up &&
+        (m->x < x_offset - MENU_X_OFFSET - MENU_CLICK_MARGIN ||
+            m->x > x_offset + MENU_CLICK_MARGIN ||
+            m->y < data.y_offset + MENU_Y_OFFSET - MENU_CLICK_MARGIN ||
+            m->y > data.y_offset + MENU_Y_OFFSET + MENU_CLICK_MARGIN + MENU_ITEM_HEIGHT * data.num_items);
+}
+
 static int handle_build_submenu(const mouse *m)
 {
     return generic_buttons_handle_mouse(
-        m, get_sidebar_x_offset() - 170, data.y_offset + 110,
+        m, get_sidebar_x_offset() - MENU_X_OFFSET, data.y_offset + MENU_Y_OFFSET,
                build_menu_buttons, data.num_items, &data.focus_button_id);
 }
 
@@ -112,7 +129,8 @@ static void handle_input(const mouse *m, const hotkeys *h)
         widget_sidebar_editor_handle_mouse_build_menu(m)) {
         return;
     }
-    if (input_go_back_requested(m, h)) {
+    if (input_go_back_requested(m, h) || click_outside_menu(m, get_sidebar_x_offset())) {
+        data.selected_submenu = MENU_NONE;
         window_editor_map_show();
     }
 }
@@ -162,12 +180,17 @@ static void button_menu_item(int index, int param2)
             }
             break;
     }
-
+    data.selected_submenu = MENU_NONE;
     window_editor_map_show();
 }
 
 void window_editor_build_menu_show(int submenu)
 {
+    if (submenu == MENU_NONE || submenu == data.selected_submenu) {
+        data.selected_submenu = MENU_NONE;
+        window_editor_map_show();
+        return;
+    }
     init(submenu);
     window_type window = {
         WINDOW_EDITOR_BUILD_MENU,

--- a/src/window/editor/build_menu.h
+++ b/src/window/editor/build_menu.h
@@ -2,6 +2,7 @@
 #define WINDOW_EDITOR_BUILD_MENU_H
 
 enum {
+    MENU_NONE = -1,
     MENU_BRUSH_SIZE = 0,
     MENU_PEOPLE_POINTS = 1,
     MENU_ELEVATION = 2,

--- a/src/window/editor/build_menu.h
+++ b/src/window/editor/build_menu.h
@@ -15,4 +15,6 @@ enum {
 
 void window_editor_build_menu_show(int submenu);
 
+void window_editor_build_menu_hide(void);
+
 #endif // WINDOW_EDITOR_BUILD_MENU_H

--- a/src/window/military_menu.c
+++ b/src/window/military_menu.c
@@ -11,6 +11,11 @@
 #include "widget/sidebar/military.h"
 #include "window/city.h"
 
+#define MENU_X_OFFSET 170
+#define MENU_Y_OFFSET 72
+#define MENU_ITEM_HEIGHT 24
+#define MENU_CLICK_MARGIN 20
+
 static struct {
     int active_buttons;
     int focus_button_id;
@@ -53,13 +58,28 @@ static void draw_foreground(void)
     data.active_buttons = num_legions;
 }
 
+static int click_outside_menu(const mouse *m, int x_offset)
+{
+    return m->left.went_down &&
+          (m->x < x_offset - MENU_X_OFFSET - MENU_CLICK_MARGIN ||
+           m->x > x_offset + MENU_CLICK_MARGIN ||
+           m->y < MENU_Y_OFFSET - MENU_CLICK_MARGIN ||
+           m->y > MENU_Y_OFFSET + MENU_CLICK_MARGIN + MENU_ITEM_HEIGHT * data.active_buttons);
+}
+
+
 static void handle_input(const mouse *m, const hotkeys *h)
 {
-    if (generic_buttons_handle_mouse(m, get_sidebar_x_offset() - 170, 72,
+    int x_offset = get_sidebar_x_offset();
+    if (generic_buttons_handle_mouse(m, x_offset - MENU_X_OFFSET, MENU_Y_OFFSET,
         menu_buttons, data.active_buttons, &data.focus_button_id)) {
         return;
     }
     if (input_go_back_requested(m, h)) {
+        window_go_back();
+        return;
+    }
+    if (click_outside_menu(m, x_offset)) {
         window_go_back();
     }
 }

--- a/src/window/military_menu.c
+++ b/src/window/military_menu.c
@@ -60,7 +60,7 @@ static void draw_foreground(void)
 
 static int click_outside_menu(const mouse *m, int x_offset)
 {
-    return m->left.went_down &&
+    return m->left.went_up &&
           (m->x < x_offset - MENU_X_OFFSET - MENU_CLICK_MARGIN ||
            m->x > x_offset + MENU_CLICK_MARGIN ||
            m->y < MENU_Y_OFFSET - MENU_CLICK_MARGIN ||

--- a/src/window/overlay_menu.c
+++ b/src/window/overlay_menu.c
@@ -147,7 +147,7 @@ static void handle_submenu_focus(void)
 
 static int click_outside_menu(const mouse *m, int x_offset)
 {
-    return m->left.went_down &&
+    return m->left.went_up &&
           (m->x < x_offset - MENU_CLICK_MARGIN - (data.selected_submenu ? SUBMENU_X_OFFSET : MENU_X_OFFSET) ||
            m->x > x_offset + MENU_CLICK_MARGIN ||
            m->y < MENU_Y_OFFSET - MENU_CLICK_MARGIN ||

--- a/src/window/overlay_menu.c
+++ b/src/window/overlay_menu.c
@@ -11,6 +11,14 @@
 #include "input/input.h"
 #include "window/city.h"
 
+#define MENU_X_OFFSET 170
+#define SUBMENU_X_OFFSET 348
+#define MENU_Y_OFFSET 72
+#define MENU_ITEM_HEIGHT 24
+#define MENU_CLICK_MARGIN 20
+
+#define MAX_BUTTONS 8
+
 static void button_menu_item(int index, int param2);
 static void button_submenu_item(int index, int param2);
 
@@ -39,10 +47,10 @@ static generic_button submenu_buttons[] = {
     {0, 216, 160, 24, button_submenu_item, button_none, 9, 0},
 };
 
-static const int MENU_ID_TO_OVERLAY[8] = {OVERLAY_NONE, OVERLAY_WATER, 1, 3, 5, 6, 7, OVERLAY_RELIGION};
-static const int MENU_ID_TO_SUBMENU_ID[8] = {0, 0, 1, 2, 3, 4, 5, 0};
+static const int MENU_ID_TO_OVERLAY[MAX_BUTTONS] = {OVERLAY_NONE, OVERLAY_WATER, 1, 3, 5, 6, 7, OVERLAY_RELIGION};
+static const int MENU_ID_TO_SUBMENU_ID[MAX_BUTTONS] = {0, 0, 1, 2, 3, 4, 5, 0};
 
-static const int SUBMENU_ID_TO_OVERLAY[6][8] = {
+static const int SUBMENU_ID_TO_OVERLAY[6][MAX_BUTTONS] = {
     {0},
     {OVERLAY_FIRE, OVERLAY_DAMAGE, OVERLAY_CRIME, OVERLAY_NATIVE, OVERLAY_PROBLEMS, 0},
     {OVERLAY_ENTERTAINMENT, OVERLAY_THEATER, OVERLAY_AMPHITHEATER, OVERLAY_COLOSSEUM, OVERLAY_HIPPODROME, 0},
@@ -137,18 +145,27 @@ static void handle_submenu_focus(void)
     }
 }
 
+static int click_outside_menu(const mouse *m, int x_offset)
+{
+    return m->left.went_down &&
+          (m->x < x_offset - MENU_CLICK_MARGIN - (data.selected_submenu ? SUBMENU_X_OFFSET : MENU_X_OFFSET) ||
+           m->x > x_offset + MENU_CLICK_MARGIN ||
+           m->y < MENU_Y_OFFSET - MENU_CLICK_MARGIN ||
+           m->y > MENU_Y_OFFSET + MENU_CLICK_MARGIN + MENU_ITEM_HEIGHT * MAX_BUTTONS);
+}
+
 static void handle_input(const mouse *m, const hotkeys *h)
 {
     int x_offset = get_sidebar_x_offset();
     int handled = 0;
-    handled |= generic_buttons_handle_mouse(m, x_offset - 170, 72, menu_buttons, 8, &data.menu_focus_button_id);
+    handled |= generic_buttons_handle_mouse(m, x_offset - MENU_X_OFFSET, MENU_Y_OFFSET, menu_buttons, MAX_BUTTONS, &data.menu_focus_button_id);
 
     if (!data.keep_submenu_open) {
         handle_submenu_focus();
     }
     if (data.selected_submenu) {
         handled |= generic_buttons_handle_mouse(
-            m, x_offset - 348, 72 + 24 * data.selected_menu,
+            m, x_offset - SUBMENU_X_OFFSET, MENU_Y_OFFSET + MENU_ITEM_HEIGHT * data.selected_menu,
             submenu_buttons, data.num_submenu_items, &data.submenu_focus_button_id);
     }
     if (!handled && input_go_back_requested(m, h)) {
@@ -157,6 +174,11 @@ static void handle_input(const mouse *m, const hotkeys *h)
         } else {
             window_city_show();
         }
+        return;
+    }
+    if (!handled && click_outside_menu(m, x_offset)) {
+        close_submenu();
+        window_city_show();
     }
 }
 


### PR DESCRIPTION
Clicking outside overlays/military/build menu closes the menu (fixes #534)

Clicking a build menu icon button for a menu that is already open closes it