### PR TITLE
Do not display hippodrome footprints if it cannot be built

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -502,7 +502,8 @@ void building_construction_update(int x, int y, int grid_offset)
     } else if (type == BUILDING_HIPPODROME) {
         if (map_building_tiles_are_clear(x, y, 5, TERRAIN_ALL) &&
             map_building_tiles_are_clear(x + 5, y, 5, TERRAIN_ALL) &&
-            map_building_tiles_are_clear(x + 10, y, 5, TERRAIN_ALL)) {
+            map_building_tiles_are_clear(x + 10, y, 5, TERRAIN_ALL) &&
+            !city_buildings_has_hippodrome()) {
             mark_construction(x, y, 5, TERRAIN_ALL, 0);
         }
     } else if (type == BUILDING_SHIPYARD || type == BUILDING_WHARF) {


### PR DESCRIPTION
This was originally proposed as a fix for Augustus, but as @crudelios suggested, here is a PR for Julius as well.

AFAIK, the fix is purely visual, it should not have any impact on save game compatibility.

As this bug was originally present in the original C3, I will totally understand if you don't want to merge this fix.

Here is a screenshot of the bug as seen in C3:

![image](https://user-images.githubusercontent.com/75644348/102531495-ac07bd00-40a2-11eb-84eb-296415c621bd.png)
