### PR TITLE
Add ability to view minimap from CCK selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ set(WIDGET_FILES
     ${PROJECT_SOURCE_DIR}/src/widget/map_editor.c
     ${PROJECT_SOURCE_DIR}/src/widget/map_editor_tool.c
     ${PROJECT_SOURCE_DIR}/src/widget/minimap.c
+    ${PROJECT_SOURCE_DIR}/src/widget/scenario_minimap.c
     ${PROJECT_SOURCE_DIR}/src/widget/top_menu.c
     ${PROJECT_SOURCE_DIR}/src/widget/top_menu_editor.c
     ${PROJECT_SOURCE_DIR}/src/widget/sidebar/city.c

--- a/src/game/file.c
+++ b/src/game/file.c
@@ -343,6 +343,7 @@ int game_file_load_scenario_data(const char *scenario_file)
 
     trade_prices_reset();
     load_empire_data(1, scenario_empire_id());
+    city_view_reset_orientation();
     return 1;
 }
 

--- a/src/widget/scenario_minimap.c
+++ b/src/widget/scenario_minimap.c
@@ -108,9 +108,6 @@ static void draw_minimap_tile(int x_view, int y_view, int grid_offset)
             switch (map_property_multi_tile_size(grid_offset)) {
                 case 1: image_draw(image_id, x_view, y_view); break;
                 case 2: image_draw(image_id + 1, x_view, y_view - 1); break;
-                case 3: image_draw(image_id + 2, x_view, y_view - 2); break;
-                case 4: image_draw(image_id + 3, x_view, y_view - 3); break;
-                case 5: image_draw(image_id + 4, x_view, y_view - 4); break;
             }
         }
     } else {

--- a/src/widget/scenario_minimap.c
+++ b/src/widget/scenario_minimap.c
@@ -1,0 +1,144 @@
+#include "minimap.h"
+
+#include "city/view.h"
+#include "graphics/graphics.h"
+#include "graphics/image.h"
+#include "map/property.h"
+#include "map/random.h"
+#include "map/terrain.h"
+#include "scenario/property.h"
+
+typedef struct {
+    color_t left;
+    color_t right;
+} tile_color;
+
+typedef struct {
+    tile_color water[4];
+    tile_color tree[4];
+    tile_color rock[4];
+    tile_color meadow[4];
+    tile_color grass[8];
+    tile_color road;
+} tile_color_set;
+
+// Since the minimap tiles are only 25 color sets per climate, we just hardcode them.
+// This "hack" is necessary to avoid reloading the climate graphics when selecting
+// a scenario with another climate in the CCK selection screen, which is expensive.
+const tile_color_set MINIMAP_COLOR_SETS[3] = {
+    // central
+    {
+        .water = {{0x394a7b, 0x31427b}, {0x394a7b, 0x314273}, {0x313973, 0x314273}, {0x31427b, 0x394a7b}},
+        .tree = {{0x6b8431, 0x102108}, {0x103908, 0x737b29}, {0x103108, 0x526b21}, {0x737b31, 0x084a10}},
+        .rock = {{0x948484, 0x635a4a}, {0xa59c94, 0xb5ada5}, {0xb5ada5, 0x8c8484}, {0x635a4a, 0xa59c94}},
+        .meadow = {{0xd6bd63, 0x9c8c39}, {0x948c39, 0xd6bd63}, {0xd6bd63, 0x9c9439}, {0x848431, 0xada54a}},
+        .grass = {
+            {0x6b8c31, 0x6b7b29}, {0x738431, 0x6b7b29}, {0x6b7329, 0x7b8c39}, {0x527b29, 0x6b7321},
+            {0x6b8431, 0x737b31}, {0x6b7b31, 0x737b29}, {0x636b18, 0x526b21}, {0x737b31, 0x737b29}
+        },
+        .road = {0x736b63, 0x4a3121}
+    },
+    // northern
+    {
+        .water = {{0x394a7b, 0x31427b}, {0x394a7b, 0x314273}, {0x313973, 0x314273}, {0x31427b, 0x394a7b}},
+        .tree = {{0x527b31, 0x082108}, {0x083908, 0x5a7329}, {0x082908, 0x316b21}, {0x527b29, 0x084a21}},
+        .rock = {{0x8c8484, 0x5a5252}, {0x9c9c94, 0xa5a5a5}, {0xa5a5a5, 0x848484}, {0x5a5252, 0x9c9c94}},
+        .meadow = {{0x427318, 0x8c9442}, {0xb5ad4a, 0x738c39}, {0x8c8c39, 0x6b7b29}, {0x527331, 0x5a8442}},
+        .grass = {
+            {0x4a8431, 0x4a7329}, {0x527b29, 0x4a7329}, {0x526b29, 0x5a8439}, {0x397321, 0x4a6b21},
+            {0x527b31, 0x5a7331}, {0x4a7329, 0x5a7329}, {0x4a6b18, 0x316b21}, {0x527b29, 0x527329}
+        },
+        .road = {0x736b63, 0x4a3121}
+    },
+    // desert
+    {
+        .water = {{0x4a84c6, 0x4a7bc6}, {0x4a84c6, 0x4a7bc6}, {0x4a84c6, 0x5284c6}, {0x4a7bbd, 0x4a7bc6}},
+        .tree = {{0xa59c7b, 0x6b7b18}, {0x214210, 0xada573}, {0x526b21, 0xcec6a5}, {0xa59c7b, 0x316321}},
+        .rock = {{0xa59494, 0x736352}, {0xa59c94, 0xb5ada5}, {0xb5ada5, 0x8c847b}, {0x736352, 0xbdada5}},
+        .meadow = {{0x739c31, 0x9cbd52}, {0x7bb529, 0x63ad21}, {0x9cbd52, 0x8c944a}, {0x7ba539, 0x739c31}},
+        .grass = {
+            {0xbdbd9c, 0xb5b594}, {0xc6bda5, 0xbdbda5}, {0xbdbd9c, 0xc6c6ad}, {0xd6cead, 0xc6bd9c},
+            {0xa59c7b, 0xbdb594}, {0xcecead, 0xb5ad94}, {0xc6c6a5, 0xdedebd}, {0xcecead, 0xd6d6b5}
+        },
+        .road = {0x6b5a52, 0x4a4239}
+    }
+};
+
+static struct {
+    int absolute_x;
+    int absolute_y;
+    int width_tiles;
+    int height_tiles;
+    int x_offset;
+    int y_offset;
+} data;
+
+static void foreach_map_tile(map_callback *callback)
+{
+    city_view_foreach_minimap_tile(
+        data.x_offset, data.y_offset, data.absolute_x, data.absolute_y,
+        data.width_tiles, data.height_tiles, callback);
+}
+
+static void set_bounds(int x_offset, int y_offset, int width, int height)
+{
+    data.width_tiles = width / 2;
+    data.height_tiles = height;
+    data.x_offset = x_offset;
+    data.y_offset = y_offset;
+    data.absolute_x = (VIEW_X_MAX - data.width_tiles) / 2;
+    data.absolute_y = (VIEW_Y_MAX - data.height_tiles) / 2;
+
+    // ensure even height
+    data.absolute_y &= ~1;
+}
+
+static void draw_minimap_tile(int x_view, int y_view, int grid_offset)
+{
+    if (grid_offset < 0) {
+        return;
+    }
+
+    int terrain = map_terrain_get(grid_offset);
+
+    if (terrain & TERRAIN_BUILDING) {
+        // Native huts/fields
+        if (map_property_is_draw_tile(grid_offset)) {
+            int image_id = image_group(GROUP_MINIMAP_BUILDING);
+            switch (map_property_multi_tile_size(grid_offset)) {
+                case 1: image_draw(image_id, x_view, y_view); break;
+                case 2: image_draw(image_id + 1, x_view, y_view - 1); break;
+                case 3: image_draw(image_id + 2, x_view, y_view - 2); break;
+                case 4: image_draw(image_id + 3, x_view, y_view - 3); break;
+                case 5: image_draw(image_id + 4, x_view, y_view - 4); break;
+            }
+        }
+    } else {
+        int rand = map_random_get(grid_offset);
+        const tile_color *color;
+        const tile_color_set *set = &MINIMAP_COLOR_SETS[scenario_property_climate()];
+        if (terrain & TERRAIN_WATER) {
+            color = &set->water[rand & 3];
+        } else if (terrain & (TERRAIN_SHRUB | TERRAIN_TREE)) {
+            color = &set->tree[rand & 3];
+        } else if (terrain & (TERRAIN_ROCK | TERRAIN_ELEVATION)) {
+            color = &set->rock[rand & 3];
+        } else if (terrain & TERRAIN_ROAD) {
+            color = &set->road;
+        } else if (terrain & TERRAIN_MEADOW) {
+            color = &set->meadow[rand & 3];
+        } else {
+            color = &set->grass[rand & 7];
+        }
+        graphics_draw_vertical_line(x_view, y_view, y_view, color->left);
+        graphics_draw_vertical_line(x_view + 1, y_view, y_view, color->right);
+    }
+}
+
+void widget_scenario_minimap_draw(int x_offset, int y_offset, int width, int height)
+{
+    set_bounds(x_offset, y_offset, width + 2, height);
+    graphics_set_clip_rectangle(x_offset, y_offset, width, height);
+    foreach_map_tile(draw_minimap_tile);
+    graphics_reset_clip_rectangle();
+}

--- a/src/widget/scenario_minimap.h
+++ b/src/widget/scenario_minimap.h
@@ -1,0 +1,6 @@
+#ifndef WIDGET_SCENARIO_MINIMAP_H
+#define WIDGET_SCENARIO_MINIMAP_H
+
+void widget_scenario_minimap_draw(int x_offset, int y_offset, int width, int height);
+
+#endif // WIDGET_SCENARIO_MINIMAP_H

--- a/src/window/cck_selection.c
+++ b/src/window/cck_selection.c
@@ -20,6 +20,7 @@
 #include "scenario/map.h"
 #include "scenario/property.h"
 #include "sound/music.h"
+#include "widget/scenario_minimap.h"
 #include "window/city.h"
 
 #include <string.h>
@@ -28,10 +29,14 @@
 
 static void button_select_item(int index, int param2);
 static void button_start_scenario(int param1, int param2);
+static void button_toggle_minimap(int param1, int param2);
 static void on_scroll(void);
 
 static image_button start_button =
     {600, 440, 27, 27, IB_NORMAL, GROUP_SIDEBAR_BUTTONS, 56, button_start_scenario, button_none, 1, 0, 1};
+
+static generic_button toggle_minimap_button =
+    {570, 87, 39, 28, button_toggle_minimap, button_none, 0, 0};
 
 static generic_button file_buttons[] = {
     {18, 220, 252, 16, button_select_item, button_none, 0, 0},
@@ -55,7 +60,9 @@ static scrollbar_type scrollbar = {276, 210, 256, on_scroll, 8, 1};
 
 static struct {
     int focus_button_id;
+    int focus_toggle_button;
     int selected_item;
+    int show_minimap;
     char selected_scenario_filename[FILE_NAME_MAX];
     uint8_t selected_scenario_display[FILE_NAME_MAX];
 
@@ -104,80 +111,94 @@ static void draw_scenario_info(void)
         scenario_info_x, 25, scenario_info_width + 10, FONT_LARGE_BLACK, 0);
     text_draw_centered(scenario_brief_description(), scenario_info_x, 60, scenario_info_width, FONT_NORMAL_WHITE, 0);
     lang_text_draw_year(scenario_property_start_year(), scenario_criteria_x, 90, FONT_LARGE_BLACK);
-    lang_text_draw_centered(44, 77 + scenario_property_climate(),
-        scenario_info_x, 150, scenario_info_width, FONT_NORMAL_BLACK);
 
-    // map size
-    int text_id;
-    switch (scenario_map_size()) {
-        case 40: text_id = 121; break;
-        case 60: text_id = 122; break;
-        case 80: text_id = 123; break;
-        case 100: text_id = 124; break;
-        case 120: text_id = 125; break;
-        default: text_id = 126; break;
-    }
-    lang_text_draw_centered(44, text_id, scenario_info_x, 170, scenario_info_width, FONT_NORMAL_BLACK);
-
-    // military
-    int num_invasions = scenario_invasion_count();
-    if (num_invasions <= 0) {
-        text_id = 112;
-    } else if (num_invasions <= 2) {
-        text_id = 113;
-    } else if (num_invasions <= 4) {
-        text_id = 114;
-    } else if (num_invasions <= 10) {
-        text_id = 115;
+    if (data.show_minimap) {
+        widget_scenario_minimap_draw(332, 119, 286, 300);
+        // minimap button: draw mission instructions image
+        image_draw(image_group(GROUP_SIDEBAR_BRIEFING_ROTATE_BUTTONS),
+            toggle_minimap_button.x + 3, toggle_minimap_button.y + 3);
     } else {
-        text_id = 116;
-    }
-    lang_text_draw_centered(44, text_id, scenario_info_x, 190, scenario_info_width, FONT_NORMAL_BLACK);
+        // minimap button: draw minimap
+        widget_scenario_minimap_draw(
+            toggle_minimap_button.x + 3, toggle_minimap_button.y + 3,
+            toggle_minimap_button.width - 6, toggle_minimap_button.height - 6
+        );
 
-    lang_text_draw_centered(32, 11 + scenario_property_player_rank(),
-        scenario_info_x, 210, scenario_info_width, FONT_NORMAL_BLACK);
-    if (scenario_is_open_play()) {
-        if (scenario_open_play_id() < 12) {
-            lang_text_draw_multiline(145, scenario_open_play_id(),
-                scenario_info_x + 10, 270, scenario_info_width - 10, FONT_NORMAL_BLACK);
+        lang_text_draw_centered(44, 77 + scenario_property_climate(),
+            scenario_info_x, 150, scenario_info_width, FONT_NORMAL_BLACK);
+
+        // map size
+        int text_id;
+        switch (scenario_map_size()) {
+            case 40: text_id = 121; break;
+            case 60: text_id = 122; break;
+            case 80: text_id = 123; break;
+            case 100: text_id = 124; break;
+            case 120: text_id = 125; break;
+            default: text_id = 126; break;
         }
-    } else {
-        lang_text_draw_centered(44, 127, scenario_info_x, 262, scenario_info_width, FONT_NORMAL_BLACK);
-        int width;
-        if (scenario_criteria_culture_enabled()) {
-            width = text_draw_number(scenario_criteria_culture(), '@', " ",
-                scenario_criteria_x, 290, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 129, scenario_criteria_x + width, 290, FONT_NORMAL_BLACK);
+        lang_text_draw_centered(44, text_id, scenario_info_x, 170, scenario_info_width, FONT_NORMAL_BLACK);
+
+        // military
+        int num_invasions = scenario_invasion_count();
+        if (num_invasions <= 0) {
+            text_id = 112;
+        } else if (num_invasions <= 2) {
+            text_id = 113;
+        } else if (num_invasions <= 4) {
+            text_id = 114;
+        } else if (num_invasions <= 10) {
+            text_id = 115;
+        } else {
+            text_id = 116;
         }
-        if (scenario_criteria_prosperity_enabled()) {
-            width = text_draw_number(scenario_criteria_prosperity(), '@', " ",
-                scenario_criteria_x, 306, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 130, scenario_criteria_x + width, 306, FONT_NORMAL_BLACK);
-        }
-        if (scenario_criteria_peace_enabled()) {
-            width = text_draw_number(scenario_criteria_peace(), '@', " ",
-                scenario_criteria_x, 322, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 131, scenario_criteria_x + width, 322, FONT_NORMAL_BLACK);
-        }
-        if (scenario_criteria_favor_enabled()) {
-            width = text_draw_number(scenario_criteria_favor(), '@', " ",
-                scenario_criteria_x, 338, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 132, scenario_criteria_x + width, 338, FONT_NORMAL_BLACK);
-        }
-        if (scenario_criteria_population_enabled()) {
-            width = text_draw_number(scenario_criteria_population(), '@', " ",
-                scenario_criteria_x, 354, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 133, scenario_criteria_x + width, 354, FONT_NORMAL_BLACK);
-        }
-        if (scenario_criteria_time_limit_enabled()) {
-            width = text_draw_number(scenario_criteria_time_limit_years(), '@', " ",
-                scenario_criteria_x, 370, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 134, scenario_criteria_x + width, 370, FONT_NORMAL_BLACK);
-        }
-        if (scenario_criteria_survival_enabled()) {
-            width = text_draw_number(scenario_criteria_survival_years(), '@', " ",
-                scenario_criteria_x, 386, FONT_NORMAL_BLACK);
-            lang_text_draw(44, 135, scenario_criteria_x + width, 386, FONT_NORMAL_BLACK);
+        lang_text_draw_centered(44, text_id, scenario_info_x, 190, scenario_info_width, FONT_NORMAL_BLACK);
+
+        lang_text_draw_centered(32, 11 + scenario_property_player_rank(),
+            scenario_info_x, 210, scenario_info_width, FONT_NORMAL_BLACK);
+        if (scenario_is_open_play()) {
+            if (scenario_open_play_id() < 12) {
+                lang_text_draw_multiline(145, scenario_open_play_id(),
+                    scenario_info_x + 10, 270, scenario_info_width - 10, FONT_NORMAL_BLACK);
+            }
+        } else {
+            lang_text_draw_centered(44, 127, scenario_info_x, 262, scenario_info_width, FONT_NORMAL_BLACK);
+            int width;
+            if (scenario_criteria_culture_enabled()) {
+                width = text_draw_number(scenario_criteria_culture(), '@', " ",
+                    scenario_criteria_x, 290, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 129, scenario_criteria_x + width, 290, FONT_NORMAL_BLACK);
+            }
+            if (scenario_criteria_prosperity_enabled()) {
+                width = text_draw_number(scenario_criteria_prosperity(), '@', " ",
+                    scenario_criteria_x, 306, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 130, scenario_criteria_x + width, 306, FONT_NORMAL_BLACK);
+            }
+            if (scenario_criteria_peace_enabled()) {
+                width = text_draw_number(scenario_criteria_peace(), '@', " ",
+                    scenario_criteria_x, 322, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 131, scenario_criteria_x + width, 322, FONT_NORMAL_BLACK);
+            }
+            if (scenario_criteria_favor_enabled()) {
+                width = text_draw_number(scenario_criteria_favor(), '@', " ",
+                    scenario_criteria_x, 338, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 132, scenario_criteria_x + width, 338, FONT_NORMAL_BLACK);
+            }
+            if (scenario_criteria_population_enabled()) {
+                width = text_draw_number(scenario_criteria_population(), '@', " ",
+                    scenario_criteria_x, 354, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 133, scenario_criteria_x + width, 354, FONT_NORMAL_BLACK);
+            }
+            if (scenario_criteria_time_limit_enabled()) {
+                width = text_draw_number(scenario_criteria_time_limit_years(), '@', " ",
+                    scenario_criteria_x, 370, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 134, scenario_criteria_x + width, 370, FONT_NORMAL_BLACK);
+            }
+            if (scenario_criteria_survival_enabled()) {
+                width = text_draw_number(scenario_criteria_survival_years(), '@', " ",
+                    scenario_criteria_x, 386, FONT_NORMAL_BLACK);
+                lang_text_draw(44, 135, scenario_criteria_x + width, 386, FONT_NORMAL_BLACK);
+            }
         }
     }
     lang_text_draw_centered(44, 136, scenario_info_x, 446, scenario_info_width, FONT_NORMAL_BLACK);
@@ -197,6 +218,10 @@ static void draw_foreground(void)
 {
     graphics_in_dialog();
     image_buttons_draw(0, 0, &start_button, 1);
+    button_border_draw(
+        toggle_minimap_button.x, toggle_minimap_button.y,
+        toggle_minimap_button.width, toggle_minimap_button.height,
+        data.focus_toggle_button);
     scrollbar_draw(&scrollbar);
     draw_scenario_list();
     graphics_reset_dialog();
@@ -209,6 +234,9 @@ static void handle_input(const mouse *m, const hotkeys *h)
         return;
     }
     if (image_buttons_handle_mouse(m_dialog, 0, 0, &start_button, 1, 0)) {
+        return;
+    }
+    if (generic_buttons_handle_mouse(m_dialog, 0, 0, &toggle_minimap_button, 1, &data.focus_toggle_button)) {
         return;
     }
     if (generic_buttons_handle_mouse(m_dialog, 0, 0, file_buttons, MAX_SCENARIOS, &data.focus_button_id)) {
@@ -242,6 +270,12 @@ static void button_start_scenario(int param1, int param2)
         sound_music_update(1);
         window_city_show();
     }
+}
+
+static void button_toggle_minimap(int param1, int param2)
+{
+    data.show_minimap = !data.show_minimap;
+    window_invalidate();
 }
 
 static void on_scroll(void)

--- a/src/window/cck_selection.c
+++ b/src/window/cck_selection.c
@@ -74,6 +74,8 @@ static void init(void)
     scenario_set_custom(2);
     data.scenarios = dir_find_files_with_extension("map");
     data.focus_button_id = 0;
+    data.focus_toggle_button = 0;
+    data.show_minimap = 0;
     button_select_item(0, 0);
     scrollbar_init(&scrollbar, 0, data.scenarios->num_files - MAX_SCENARIOS);
 }


### PR DESCRIPTION
A personal pet peeve: there's no way to preview the maps in the CCK selection screen. This PR fixes that:
![cck-minimap-button](https://user-images.githubusercontent.com/104874/103313015-10216e00-4a1f-11eb-9888-d33d6cf963b2.png)

The little minimap-like button is a toggle between the regular scenario conditions and the minimap:
![cck-minimap-result](https://user-images.githubusercontent.com/104874/103313044-2a5b4c00-4a1f-11eb-9931-a93abd1a1368.png)
