### PR TITLE
MacOS: fix mp3 playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,6 +664,7 @@ if(APPLE)
         MACOSX_BUNDLE_INFO_PLIST "${PROJECT_SOURCE_DIR}/res/Info.plist.in")
 
     set(DIRS "")
+    set(LIBS "")
 
     # if SDL2 library is a framework, we need to indicate to CMake
     # the path to its dependencies. SDL2_LIBRARY contains two parts.
@@ -678,13 +679,17 @@ if(APPLE)
     # the path to its dependencies (Ogg.framework etc):
     if(EXISTS "${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
         list(APPEND DIRS "${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
+        # Copy mpg123 framework manually because since MacOS 10.15, the
+        # dependency is seen as "weak" and not copied automatically
+        file(COPY "${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks/mpg123.framework" DESTINATION "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Frameworks")
+        list(APPEND LIBS "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Frameworks/mpg123.framework/mpg123")
     endif()
 
-    # when installing, "fixup" automatically copies librairies inside the
+    # when installing, "fixup" automatically copies libraries inside the
     # bundle and links the binary against them
     install(CODE "
         include(BundleUtilities)
-        fixup_bundle(${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app \"\" \"${DIRS}\")
+        fixup_bundle(${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app \"${LIBS}\" \"${DIRS}\")
     " BUNDLE DESTINATION ${CMAKE_BINARY_DIR})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,13 +671,13 @@ if(APPLE)
     # So strip out everything after the ';'
     string(REGEX REPLACE ";.*$" "" SDL2_LIB_DIR "${SDL2_LIBRARY}")
     if(EXISTS "${SDL2_LIB_DIR}/Versions/A/Frameworks")
-        set(DIRS "${DIRS};${SDL2_LIB_DIR}/Versions/A/Frameworks")
+        list(APPEND DIRS "${SDL2_LIB_DIR}/Versions/A/Frameworks")
     endif()
 
     # if SDL2_mixer library is a framework, we need to indicate to CMake
     # the path to its dependencies (Ogg.framework etc):
     if(EXISTS "${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
-        set(DIRS "${DIRS};${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
+        list(APPEND DIRS "${SDL2_MIXER_LIBRARY}/Versions/A/Frameworks")
     endif()
 
     # when installing, "fixup" automatically copies librairies inside the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,6 +690,11 @@ if(APPLE)
     install(CODE "
         include(BundleUtilities)
         fixup_bundle(${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app \"${LIBS}\" \"${DIRS}\")
+        # Manually fix up link to mpg123 in SDL2_mixer
+        execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL}
+            \"-change\" \"@rpath/mpg123.framework/Versions/A/mpg123\"
+            \"@executable_path/../Frameworks/mpg123.framework/mpg123\"
+            \"${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Frameworks/SDL2_mixer.framework/Versions/A/SDL2_mixer\")
     " BUNDLE DESTINATION ${CMAKE_BINARY_DIR})
 endif()
 


### PR DESCRIPTION
Since switching CI to Github Actions, the macos app bundle no longer includes the mpg123.framework, and this breaks MP3 playback.

So far I've been unable to find a solution that only involves cmake's BundleUtilities, and this is rather hacky.

Fixes #568 