### PR TITLE
File dialog improvements

### DIFF
--- a/src/core/dir.c
+++ b/src/core/dir.c
@@ -50,7 +50,7 @@ static void expand_dir_listing(void)
 static int compare_lower(const void *va, const void *vb)
 {
     // arguments are pointers to char*
-    return string_compare_case_insensitive(*(const char**)va, *(const char**)vb);
+    return platform_file_manager_compare_filename(*(const char**)va, *(const char**)vb);
 }
 
 static int add_to_listing(const char *filename)
@@ -82,7 +82,7 @@ const dir_listing *dir_find_all_subdirectories(void)
 
 static int compare_case(const char *filename)
 {
-    if (string_compare_case_insensitive(filename, data.cased_filename) == 0) {
+    if (platform_file_manager_compare_filename(filename, data.cased_filename) == 0) {
         strcpy(data.cased_filename, filename);
         return LIST_MATCH;
     }

--- a/src/core/file.c
+++ b/src/core/file.c
@@ -29,7 +29,7 @@ int file_has_extension(const char *filename, const char *extension)
     if (!c) {
         filename--;
     }
-    return string_compare_case_insensitive(filename, extension) == 0;
+    return platform_file_manager_compare_filename(filename, extension) == 0;
 }
 
 void file_change_extension(char *filename, const char *new_extension)

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -1,16 +1,5 @@
 #include "core/string.h"
 
-#include <ctype.h>
-
-#if _MSC_VER
-// Of course MSVC is the only compiler that doesn't have strcasecmp...
-#include <string.h>
-#define strcasecmp _stricmp
-#define strncasecmp _strnicmp
-#else
-#include <strings.h>
-#endif
-
 int string_equals(const uint8_t *a, const uint8_t *b)
 {
     while (*a && *b && *a == *b) {
@@ -142,14 +131,4 @@ int string_from_int(uint8_t *dst, int value, int force_plus_sign)
     }
 
     return total_chars;
-}
-
-int string_compare_case_insensitive(const char *a, const char *b)
-{
-    return strcasecmp(a, b);
-}
-
-int string_compare_case_insensitive_prefix(const char *full_string, const char *prefix, int prefix_len)
-{
-    return strncasecmp(full_string, prefix, prefix_len);
 }

--- a/src/core/string.c
+++ b/src/core/string.c
@@ -2,6 +2,28 @@
 
 #include <ctype.h>
 
+#if _MSC_VER
+// Of course MSVC is the only compiler that doesn't have strcasecmp...
+#include <string.h>
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#else
+#include <strings.h>
+#endif
+
+int string_equals(const uint8_t *a, const uint8_t *b)
+{
+    while (*a && *b && *a == *b) {
+        ++a;
+        ++b;
+    }
+    if (*a == 0 && *b == 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 void string_copy(const uint8_t *src, uint8_t *dst, int maxlength)
 {
     int length = 0;
@@ -124,33 +146,10 @@ int string_from_int(uint8_t *dst, int value, int force_plus_sign)
 
 int string_compare_case_insensitive(const char *a, const char *b)
 {
-    while (*a && *b) {
-        int aa = tolower(*a);
-        int bb = tolower(*b);
-        if (aa != bb) {
-            return aa - bb;
-        }
-        ++a;
-        ++b;
-    }
-    if (*a) {
-        return 1;
-    }
-    if (*b) {
-        return -1;
-    }
-    return 0;
+    return strcasecmp(a, b);
 }
 
-int string_equals(const uint8_t *a, const uint8_t *b)
+int string_compare_case_insensitive_prefix(const char *full_string, const char *prefix, int prefix_len)
 {
-    while (*a && *b && *a == *b) {
-        ++a;
-        ++b;
-    }
-    if (*a == 0 && *b == 0) {
-        return 1;
-    } else {
-        return 0;
-    }
+    return strncasecmp(full_string, prefix, prefix_len);
 }

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -54,21 +54,4 @@ int string_to_int(const uint8_t *str);
  */
 int string_from_int(uint8_t *dst, int value, int force_plus_sign);
 
-/**
- * Compares the two strings case insensitively, used exclusively for filenames
- * @param a String A
- * @param b String B
- * @return Negative if A < B, positive if A > B, zero if A == B
- */
-int string_compare_case_insensitive(const char *a, const char *b);
-
-/**
- * Checks if the full string starts with the given prefix in a case-insensitive way
- * @param full_string String to check
- * @param prefix Prefix to check for
- * @param prefix_len Length of the prefix
- * @return Negative if full_string < prefix, 0 if full_string starts with prefix, positive if full_string > prefix
- */
-int string_compare_case_insensitive_prefix(const char *full_string, const char *prefix, int prefix_len);
-
 #endif // CORE_STRING_H

--- a/src/core/string.h
+++ b/src/core/string.h
@@ -9,6 +9,14 @@
  */
 
 /**
+ * Checks if the two strings are equal
+ * @param a String A
+ * @param b String B
+ * @return Boolean true if the strings are equal, false if they differ
+ */
+int string_equals(const uint8_t *a, const uint8_t *b);
+
+/**
  * Copies a string
  * @param src Source string
  * @param dst Destination string
@@ -55,11 +63,12 @@ int string_from_int(uint8_t *dst, int value, int force_plus_sign);
 int string_compare_case_insensitive(const char *a, const char *b);
 
 /**
- * Checks if the two strings are equal
- * @param a String A
- * @param b String B
- * @return Boolean true if the strings are equal, false if they differ
+ * Checks if the full string starts with the given prefix in a case-insensitive way
+ * @param full_string String to check
+ * @param prefix Prefix to check for
+ * @param prefix_len Length of the prefix
+ * @return Negative if full_string < prefix, 0 if full_string starts with prefix, positive if full_string > prefix
  */
-int string_equals(const uint8_t *a, const uint8_t *b);
+int string_compare_case_insensitive_prefix(const char *full_string, const char *prefix, int prefix_len);
 
 #endif // CORE_STRING_H

--- a/src/platform/file_manager.c
+++ b/src/platform/file_manager.c
@@ -12,6 +12,13 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#if _MSC_VER
+// Of course MSVC is the only compiler that doesn't have POSIX strcasecmp...
+#include <mbstring.h>
+#else
+#include <strings.h>
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 
@@ -171,6 +178,24 @@ int platform_file_manager_should_case_correct_file(void)
     return 0;
 #else
     return 1;
+#endif
+}
+
+int platform_file_manager_compare_filename(const char *a, const char *b)
+{
+#if _MSC_VER
+    return _mbsicmp((const unsigned char *)a, (const unsigned char *)b);
+#else
+    return strcasecmp(a, b);
+#endif
+}
+
+int platform_file_manager_compare_filename_prefix(const char *filename, const char *prefix, int prefix_len)
+{
+#if _MSC_VER
+    return _mbsnicmp((const unsigned char *)filename, (const unsigned char *)prefix, prefix_len);
+#else
+    return strncasecmp(filename, prefix, prefix_len);
 #endif
 }
 

--- a/src/platform/file_manager.h
+++ b/src/platform/file_manager.h
@@ -42,6 +42,23 @@ int platform_file_manager_list_directory_contents(
 int platform_file_manager_should_case_correct_file(void);
 
 /**
+ * Compares two filenames in a case-insensitive manner
+ * @param a Filename A
+ * @param b Filename B
+ * @return Negative if A < B, positive if A > B, zero if A == B
+ */
+int platform_file_manager_compare_filename(const char *a, const char *b);
+
+/**
+ * Checks if the filename starts with the given prefix in a case-insensitive manner
+ * @param filename Filename to check
+ * @param prefix Prefix to check for
+ * @param prefix_len Length of the prefix
+ * @return Negative if filename < prefix, 0 if filename starts with prefix, positive if filename > prefix
+ */
+int platform_file_manager_compare_filename_prefix(const char *filename, const char *prefix, int prefix_len);
+
+/**
  * Opens a file
  * @param filename The file to open
  * @param mode The mode to open the file - refer to fopen()

--- a/src/platform/file_manager_cache.c
+++ b/src/platform/file_manager_cache.c
@@ -162,7 +162,7 @@ int platform_file_manager_cache_file_has_extension(const file_info *f, const cha
     if (!(f->type & TYPE_FILE) || !extension || !*extension) {
         return 1;
     }
-    return string_compare_case_insensitive(f->extension, extension) == 0;
+    return platform_file_manager_compare_filename(f->extension, extension) == 0;
 }
 
 #endif // __vita__

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -84,15 +84,19 @@ static void init(file_type type, file_dialog_type dialog_type)
 {
     data.type = type;
     data.file_data = type == FILE_TYPE_SCENARIO ? &scenario_data : &saved_game_data;
-    if (strlen(data.file_data->last_loaded_file) == 0) {
-        string_copy(lang_get_string(9, type == FILE_TYPE_SCENARIO ? 7 : 6), data.typed_name, FILE_NAME_MAX);
-        encoding_to_utf8(data.typed_name, data.file_data->last_loaded_file, FILE_NAME_MAX, 0);
-        file_append_extension(data.file_data->last_loaded_file, data.file_data->extension);
-    } else {
+    data.dialog_type = dialog_type;
+
+    if (strlen(data.file_data->last_loaded_file) > 0) {
         encoding_from_utf8(data.file_data->last_loaded_file, data.typed_name, FILE_NAME_MAX);
         file_remove_extension(data.typed_name);
+    } else if (dialog_type == FILE_DIALOG_SAVE) {
+        // Suggest default filename
+        string_copy(lang_get_string(9, type == FILE_TYPE_SCENARIO ? 7 : 6), data.typed_name, FILE_NAME_MAX);
+    } else {
+        // Use empty string
+        data.typed_name[0] = 0;
     }
-    data.dialog_type = dialog_type;
+
     data.message_not_exist_start_time = 0;
 
     data.file_list = dir_find_files_with_extension(data.file_data->extension);

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -80,22 +80,36 @@ static input_box file_name_input = {144, 80, 20, 2, FONT_NORMAL_WHITE, 0, data.t
 static file_type_data saved_game_data = {"sav"};
 static file_type_data scenario_data = {"map"};
 
+static int find_first_file_with_prefix(const char *prefix)
+{
+    int len = strlen(prefix);
+    if (len == 0) {
+        return -1;
+    }
+    int left = 0;
+    int right = data.file_list->num_files;
+    while (left < right) {
+        int middle = (left + right) / 2;
+        if (string_compare_case_insensitive_prefix(data.file_list->files[middle], prefix, len) >= 0) {
+            right = middle;
+        } else {
+            left = middle + 1;
+        }
+    }
+    if (string_compare_case_insensitive_prefix(data.file_list->files[left], prefix, len) == 0) {
+        return left;
+    } else {
+        return -1;
+    }
+}
+
 static void scroll_to_typed_text(void)
 {
     char name_utf8[FILE_NAME_MAX];
     encoding_to_utf8(data.typed_name, name_utf8, FILE_NAME_MAX, encoding_system_uses_decomposed());
-    size_t len = strlen(name_utf8);
-    if (len == 0) {
-        return;
-    }
-    for (int i = 0; i < data.file_list->num_files; i++) {
-        int cmp_result = strncasecmp(data.file_list->files[i], name_utf8, len);
-        if (cmp_result == 0) {
-            scrollbar_reset(&scrollbar, calc_bound(i, 0, data.file_list->num_files - NUM_FILES_IN_VIEW));
-        }
-        if (cmp_result >= 0) {
-            break;
-        }
+    int index = find_first_file_with_prefix(name_utf8);
+    if (index >= 0) {
+        scrollbar_reset(&scrollbar, calc_bound(index, 0, data.file_list->num_files - NUM_FILES_IN_VIEW));
     }
 }
 

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -66,6 +66,7 @@ static struct {
     file_type type;
     file_dialog_type dialog_type;
     int focus_button_id;
+    int double_click;
     const dir_listing *file_list;
 
     file_type_data *file_data;
@@ -78,13 +79,15 @@ static input_box file_name_input = {144, 80, 20, 2, FONT_NORMAL_WHITE, 0, data.t
 static file_type_data saved_game_data = {"sav"};
 static file_type_data scenario_data = {"map"};
 
-static int double_click = 0;
-
 static void init(file_type type, file_dialog_type dialog_type)
 {
     data.type = type;
     data.file_data = type == FILE_TYPE_SCENARIO ? &scenario_data : &saved_game_data;
     data.dialog_type = dialog_type;
+
+    data.message_not_exist_start_time = 0;
+    data.double_click = 0;
+    data.focus_button_id = 0;
 
     if (strlen(data.file_data->last_loaded_file) > 0) {
         encoding_from_utf8(data.file_data->last_loaded_file, data.typed_name, FILE_NAME_MAX);
@@ -96,8 +99,6 @@ static void init(file_type type, file_dialog_type dialog_type)
         // Use empty string
         data.typed_name[0] = 0;
     }
-
-    data.message_not_exist_start_time = 0;
 
     data.file_list = dir_find_files_with_extension(data.file_data->extension);
     scrollbar_init(&scrollbar, 0, data.file_list->num_files - NUM_FILES_IN_VIEW);
@@ -146,7 +147,7 @@ static void draw_foreground(void)
 
 static void handle_input(const mouse *m, const hotkeys *h)
 {
-    double_click = m->left.double_click;
+    data.double_click = m->left.double_click;
 
     if (input_box_is_accepted(&file_name_input)) {
         button_ok_cancel(1, 0);
@@ -255,8 +256,8 @@ static void button_select_file(int index, int param2)
         input_box_refresh_text(&file_name_input);
         data.message_not_exist_start_time = 0;
     }
-    if (data.dialog_type != FILE_DIALOG_DELETE && double_click) {
-        double_click = 0;
+    if (data.dialog_type != FILE_DIALOG_DELETE && data.double_click) {
+        data.double_click = 0;
         button_ok_cancel(1, 0);
     }
 }

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -20,6 +20,7 @@
 #include "graphics/text.h"
 #include "graphics/window.h"
 #include "input/input.h"
+#include "platform/file_manager.h"
 #include "widget/input_box.h"
 #include "window/city.h"
 #include "window/editor/map.h"
@@ -90,13 +91,13 @@ static int find_first_file_with_prefix(const char *prefix)
     int right = data.file_list->num_files;
     while (left < right) {
         int middle = (left + right) / 2;
-        if (string_compare_case_insensitive_prefix(data.file_list->files[middle], prefix, len) >= 0) {
+        if (platform_file_manager_compare_filename_prefix(data.file_list->files[middle], prefix, len) >= 0) {
             right = middle;
         } else {
             left = middle + 1;
         }
     }
-    if (string_compare_case_insensitive_prefix(data.file_list->files[left], prefix, len) == 0) {
+    if (platform_file_manager_compare_filename_prefix(data.file_list->files[left], prefix, len) == 0) {
         return left;
     } else {
         return -1;
@@ -181,7 +182,7 @@ static void draw_foreground(void)
     graphics_reset_dialog();
 }
 
-static int typed_text_has_changed()
+static int typed_text_has_changed(void)
 {
     if (string_equals(data.previously_seen_typed_name, data.typed_name)) {
         return 0;

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -83,7 +83,7 @@ static file_type_data scenario_data = {"map"};
 
 static int find_first_file_with_prefix(const char *prefix)
 {
-    int len = strlen(prefix);
+    int len = (int) strlen(prefix);
     if (len == 0) {
         return -1;
     }
@@ -182,13 +182,18 @@ static void draw_foreground(void)
     graphics_reset_dialog();
 }
 
-static int typed_text_has_changed(void)
+static int should_scroll_to_typed_text(void)
 {
     if (string_equals(data.previously_seen_typed_name, data.typed_name)) {
         return 0;
     }
+    int scroll = 0;
+    // Only scroll when adding characters to the typed name
+    if (string_length(data.typed_name) > string_length(data.previously_seen_typed_name)) {
+        scroll = 1;
+    }
     string_copy(data.typed_name, data.previously_seen_typed_name, FILE_NAME_MAX);
-    return 1;
+    return scroll;
 }
 
 static void handle_input(const mouse *m, const hotkeys *h)
@@ -212,7 +217,7 @@ static void handle_input(const mouse *m, const hotkeys *h)
         window_go_back();
     }
 
-    if (typed_text_has_changed()) {
+    if (should_scroll_to_typed_text()) {
         scroll_to_typed_text();
     }
 }
@@ -225,7 +230,7 @@ static const char *get_chosen_filename(void)
     file_remove_extension(selected_name);
 
     if (string_equals(selected_name, data.typed_name)) {
-        // user has not modified the string after selecting it: use filename
+        // User has not modified the string after selecting it: use filename
         return data.selected_file;
     }
 


### PR DESCRIPTION
This PR adds the following improvements to the file dialog:

- Typing in the input box now scrolls the list to the first file that starts with the typed text
- When loading a saved game, the placeholder filename "My Rome" is no longer pre-filled - it's only used for the "save file" dialog
- Multi-byte characters are taken into account when sorting