### PR TITLE
Update vita toolchain

### DIFF
--- a/.ci_scripts/setup_environment.sh
+++ b/.ci_scripts/setup_environment.sh
@@ -5,7 +5,7 @@ case "$BUILD_TARGET" in
 	# Note: Using a tagged version of the container to make sure that it's not updated unexpectedly
 	# You can update the tag by obtaining a recent one from here: https://hub.docker.com/r/gnuton/vitasdk-docker/tags
 	# Make sure that it compiles correctly and runs on a Vita prior to pushing the change
-	docker run -d --name vitasdk --workdir /build/git -v "${PWD}:/build/git" gnuton/vitasdk-docker:20190626 tail -f /dev/null
+	docker run -d --name vitasdk --workdir /build/git -v "${PWD}:/build/git" gnuton/vitasdk-docker:20210217 tail -f /dev/null
 	;;
 "switch")
 	docker run -d --name switchdev --workdir /build/git -v "${PWD}:/build/git" devkitpro/devkita64:20200730 tail -f /dev/null

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@ cmake_dependent_option(SWITCH_BUILD "Build for the Nintendo Switch handheld game
 cmake_dependent_option(ANDROID_BUILD "Build for the Android environment." OFF "NOT MSVC; NOT VITA_BUILD; NOT SWITCH_BUILD" OFF)
 
 if(VITA_BUILD AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    if(DEFINED ENV{DOLCESDK})
-        set(CMAKE_TOOLCHAIN_FILE "$ENV{DOLCESDK}/share/dolce.toolchain.cmake" CACHE PATH "toolchain file")
+    if(DEFINED ENV{VITASDK})
+        set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
     else()
-        message(FATAL_ERROR "Please define DOLCESDK to point to your SDK path!")
+        message(FATAL_ERROR "Please define VITASDK to point to your SDK path!")
     endif()
 endif()
 
@@ -37,7 +37,7 @@ set(USER_FRIENDLY_NAME Julius)
 project(${SHORT_NAME} C)
 
 if (VITA_BUILD)
-    include("${DOLCESDK}/share/dolce.cmake" REQUIRED)
+    include("${VITASDK}/share/vita.cmake" REQUIRED)
     set(VITA_TITLEID  "JULIUS001")
 endif()
 
@@ -710,7 +710,7 @@ endif()
 
 if(VITA_BUILD)
     include_directories(
-        $ENV{DOLCESDK}/arm-dolce-eabi/include
+        $ENV{VITASDK}/arm-vita-eabi/include
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 elseif (SWITCH_BUILD)
@@ -738,14 +738,12 @@ if (VITA_BUILD)
         mpg123
         FLAC
         ogg
-        pib
         m
         SceAppUtil_stub
         SceAudio_stub
         SceCommonDialog_stub
         SceCtrl_stub
         SceDisplay_stub
-        SceDisplayUser_stub
         SceGxm_stub
         SceHid_stub
         SceMotion_stub
@@ -756,14 +754,13 @@ if (VITA_BUILD)
         ScePower_stub
         ScePgf_stub
         SceAppMgr_stub
-        SceAppMgrUser_stub
     )
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__vita__")
     # this setting enables larger heap memory sizes on Vita, up to ~330 MB
     # useful for pre-loading videos into memory
-    set(DOLCE_MKSFOEX_FLAGS "${DOLCE_MKSFOEX_FLAGS} -d ATTRIBUTE2=12")
-    dolce_create_self(${SHORT_NAME}.self ${SHORT_NAME} UNSAFE UNCOMPRESSED)
-    dolce_create_vpk(${SHORT_NAME}.vpk ${VITA_TITLEID} ${SHORT_NAME}.self
+    set(VITA_MKSFOEX_FLAGS "${VITA_MKSFOEX_FLAGS} -d ATTRIBUTE2=12")
+    vita_create_self(${SHORT_NAME}.self ${SHORT_NAME} UNSAFE UNCOMPRESSED)
+    vita_create_vpk(${SHORT_NAME}.vpk ${VITA_TITLEID} ${SHORT_NAME}.self
         VERSION ${VITA_VERSION}
         NAME ${SHORT_NAME}
         FILE res/vita/icon0.png sce_sys/icon0.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@ cmake_dependent_option(SWITCH_BUILD "Build for the Nintendo Switch handheld game
 cmake_dependent_option(ANDROID_BUILD "Build for the Android environment." OFF "NOT MSVC; NOT VITA_BUILD; NOT SWITCH_BUILD" OFF)
 
 if(VITA_BUILD AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    if(DEFINED ENV{VITASDK})
-        set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+    if(DEFINED ENV{DOLCESDK})
+        set(CMAKE_TOOLCHAIN_FILE "$ENV{DOLCESDK}/share/dolce.toolchain.cmake" CACHE PATH "toolchain file")
     else()
-        message(FATAL_ERROR "Please define VITASDK to point to your SDK path!")
+        message(FATAL_ERROR "Please define DOLCESDK to point to your SDK path!")
     endif()
 endif()
 
@@ -37,7 +37,7 @@ set(USER_FRIENDLY_NAME Julius)
 project(${SHORT_NAME} C)
 
 if (VITA_BUILD)
-    include("${VITASDK}/share/vita.cmake" REQUIRED)
+    include("${DOLCESDK}/share/dolce.cmake" REQUIRED)
     set(VITA_TITLEID  "JULIUS001")
 endif()
 
@@ -710,7 +710,7 @@ endif()
 
 if(VITA_BUILD)
     include_directories(
-        $ENV{VITASDK}/arm-vita-eabi/include
+        $ENV{DOLCESDK}/arm-dolce-eabi/include
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 elseif (SWITCH_BUILD)
@@ -738,13 +738,14 @@ if (VITA_BUILD)
         mpg123
         FLAC
         ogg
-        vita2d
+        pib
         m
         SceAppUtil_stub
         SceAudio_stub
         SceCommonDialog_stub
         SceCtrl_stub
         SceDisplay_stub
+        SceDisplayUser_stub
         SceGxm_stub
         SceHid_stub
         SceMotion_stub
@@ -755,13 +756,14 @@ if (VITA_BUILD)
         ScePower_stub
         ScePgf_stub
         SceAppMgr_stub
+        SceAppMgrUser_stub
     )
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__vita__")
     # this setting enables larger heap memory sizes on Vita, up to ~330 MB
     # useful for pre-loading videos into memory
-    set(VITA_MKSFOEX_FLAGS "${VITA_MKSFOEX_FLAGS} -d ATTRIBUTE2=12")
-    vita_create_self(${SHORT_NAME}.self ${SHORT_NAME} UNSAFE UNCOMPRESSED)
-    vita_create_vpk(${SHORT_NAME}.vpk ${VITA_TITLEID} ${SHORT_NAME}.self
+    set(DOLCE_MKSFOEX_FLAGS "${DOLCE_MKSFOEX_FLAGS} -d ATTRIBUTE2=12")
+    dolce_create_self(${SHORT_NAME}.self ${SHORT_NAME} UNSAFE UNCOMPRESSED)
+    dolce_create_vpk(${SHORT_NAME}.vpk ${VITA_TITLEID} ${SHORT_NAME}.self
         VERSION ${VITA_VERSION}
         NAME ${SHORT_NAME}
         FILE res/vita/icon0.png sce_sys/icon0.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -747,6 +747,7 @@ if (VITA_BUILD)
         SceDisplay_stub
         SceGxm_stub
         SceHid_stub
+        SceMotion_stub
         SceIofilemgr_stub
         SceMotion_stub
         SceSysmodule_stub

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -181,7 +181,7 @@ static void run_and_draw(void)
             'd', "", 70, y_offset_text, FONT_NORMAL_PLAIN, COLOR_FONT_RED);
     }
 
-    platform_screen_render();
+    platform_screen_render(1);
 }
 #else
 static void run_and_draw(void)
@@ -191,7 +191,7 @@ static void run_and_draw(void)
     game_run();
     game_draw();
 
-    platform_screen_render();
+    platform_screen_render(1);
 }
 #endif
 

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -180,8 +180,8 @@ static void run_and_draw(void)
         text_draw_number_colored(time_after_draw - time_between_run_and_draw,
             'd', "", 70, y_offset_text, FONT_NORMAL_PLAIN, COLOR_FONT_RED);
     }
-
-    platform_screen_render(1);
+    platform_screen_update();
+    platform_screen_render();
 }
 #else
 static void run_and_draw(void)
@@ -191,7 +191,8 @@ static void run_and_draw(void)
     game_run();
     game_draw();
 
-    platform_screen_render(1);
+    platform_screen_update();
+    platform_screen_render();
 }
 #endif
 

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -350,24 +350,26 @@ void platform_screen_recreate_texture(void)
 }
 #endif
 
-void platform_screen_render(int update_screen)
-{
-    if (update_screen) {
-        SDL_RenderClear(SDL.renderer);
-#ifndef __vita__
-        SDL_UpdateTexture(SDL.texture, NULL, graphics_canvas(), screen_width() * 4);
-#endif
-        SDL_RenderCopy(SDL.renderer, SDL.texture, NULL, NULL);
-#ifdef PLATFORM_USE_SOFTWARE_CURSOR
-        draw_software_mouse_cursor();
-#endif
-    }
-    SDL_RenderPresent(SDL.renderer);
-}
-
 void platform_screen_clear(void)
 {
     SDL_RenderClear(SDL.renderer);
+}
+
+void platform_screen_update(void)
+{
+    SDL_RenderClear(SDL.renderer);
+#ifndef __vita__
+    SDL_UpdateTexture(SDL.texture, NULL, graphics_canvas(), screen_width() * 4);
+#endif
+    SDL_RenderCopy(SDL.renderer, SDL.texture, NULL, NULL);
+#ifdef PLATFORM_USE_SOFTWARE_CURSOR
+    draw_software_mouse_cursor();
+#endif
+}
+
+void platform_screen_render(void)
+{
+    SDL_RenderPresent(SDL.renderer);
 }
 
 void platform_screen_generate_mouse_cursor_texture(int cursor_id, int scale, const color_t *cursor_colors)

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -196,7 +196,7 @@ int platform_screen_resize(int pixel_width, int pixel_height)
 
     setting_set_display(setting_fullscreen(), logical_width, logical_height);
     SDL.texture = SDL_CreateTexture(SDL.renderer,
-        SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
+        SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING,
         logical_width, logical_height);
 
     if (SDL.texture) {
@@ -350,15 +350,22 @@ void platform_screen_recreate_texture(void)
 }
 #endif
 
-void platform_screen_render(void)
+void platform_screen_render(int update_screen)
+{
+    if (update_screen) {
+        SDL_RenderClear(SDL.renderer);
+        SDL_UpdateTexture(SDL.texture, NULL, graphics_canvas(), screen_width() * 4);
+        SDL_RenderCopy(SDL.renderer, SDL.texture, NULL, NULL);
+#ifdef PLATFORM_USE_SOFTWARE_CURSOR
+        draw_software_mouse_cursor();
+#endif
+    }
+    SDL_RenderPresent(SDL.renderer);
+}
+
+void platform_screen_clear(void)
 {
     SDL_RenderClear(SDL.renderer);
-    SDL_UpdateTexture(SDL.texture, NULL, graphics_canvas(), screen_width() * 4);
-    SDL_RenderCopy(SDL.renderer, SDL.texture, NULL, NULL);
-#ifdef PLATFORM_USE_SOFTWARE_CURSOR
-    draw_software_mouse_cursor();
-#endif
-    SDL_RenderPresent(SDL.renderer);
 }
 
 void platform_screen_generate_mouse_cursor_texture(int cursor_id, int scale, const color_t *cursor_colors)

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -196,7 +196,7 @@ int platform_screen_resize(int pixel_width, int pixel_height)
 
     setting_set_display(setting_fullscreen(), logical_width, logical_height);
     SDL.texture = SDL_CreateTexture(SDL.renderer,
-        SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING,
+        SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING,
         logical_width, logical_height);
 
     if (SDL.texture) {
@@ -354,7 +354,9 @@ void platform_screen_render(int update_screen)
 {
     if (update_screen) {
         SDL_RenderClear(SDL.renderer);
+#ifndef __vita__
         SDL_UpdateTexture(SDL.texture, NULL, graphics_canvas(), screen_width() * 4);
+#endif
         SDL_RenderCopy(SDL.renderer, SDL.texture, NULL, NULL);
 #ifdef PLATFORM_USE_SOFTWARE_CURSOR
         draw_software_mouse_cursor();
@@ -404,7 +406,13 @@ int system_is_fullscreen_only(void)
 
 color_t *system_create_framebuffer(int width, int height)
 {
+#ifdef __vita__
+    int pitch;
+    SDL_LockTexture(SDL.texture, NULL, (void **)&framebuffer, &pitch);
+    SDL_UnlockTexture(SDL.texture);
+#else
     free(framebuffer);
     framebuffer = (color_t *)malloc((size_t)width * height * sizeof(color_t));
+#endif
     return framebuffer;
 }

--- a/src/platform/screen.h
+++ b/src/platform/screen.h
@@ -18,7 +18,8 @@ void platform_screen_center_window(void);
 void platform_screen_recreate_texture(void);
 #endif
 
-void platform_screen_render(void);
+void platform_screen_render(int update_screen);
+void platform_screen_clear(void);
 
 void platform_screen_generate_mouse_cursor_texture(int cursor_id, int scale, const color_t *cursor_colors);
 

--- a/src/platform/screen.h
+++ b/src/platform/screen.h
@@ -18,8 +18,9 @@ void platform_screen_center_window(void);
 void platform_screen_recreate_texture(void);
 #endif
 
-void platform_screen_render(int update_screen);
 void platform_screen_clear(void);
+void platform_screen_update(void);
+void platform_screen_render(void);
 
 void platform_screen_generate_mouse_cursor_texture(int cursor_id, int scale, const color_t *cursor_colors);
 

--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #ifdef __vita__
-#include <psp2/kernel/iofilemgr.h>
+#include <psp2/io/fcntl.h>
 #endif
 
 #define AUDIO_RATE 22050

--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #ifdef __vita__
-#include <psp2/io/fcntl.h>
+#include <psp2/kernel/iofilemgr.h>
 #endif
 
 #define AUDIO_RATE 22050

--- a/src/platform/vita/vita.c
+++ b/src/platform/vita/vita.c
@@ -18,7 +18,7 @@
 static char prepended_path[2 * FILE_NAME_MAX * sizeof(char)];
 
 // max heap size is approx. 330 MB with -d ATTRIBUTE2=12, otherwise max is 192
-int _newlib_heap_size_user = 300 * 1024 * 1024;
+int _newlib_heap_size_user = 330 * 1024 * 1024;
 
 static void center_mouse_cursor(void)
 {

--- a/src/platform/vita/vita.h
+++ b/src/platform/vita/vita.h
@@ -3,7 +3,7 @@
 
 #ifdef __vita__
 
-#include <vita2d.h>
+#include <stdint.h>
 
 #define VITA_PATH_PREFIX "ux0:/data/julius/"
 #define VITA_DISPLAY_WIDTH 960

--- a/src/platform/vita/vita_keyboard.c
+++ b/src/platform/vita/vita_keyboard.c
@@ -2,16 +2,15 @@
 
 #include "core/calc.h"
 #include "core/encoding.h"
-#include "core/string.h"
+#include "platform/screen.h"
 
 #include <string.h>
 #include <psp2/apputil.h>
+#include <psp2/common_dialog.h>
 #include <psp2/display.h>
 #include <psp2/kernel/processmgr.h>
 #include <psp2/ime_dialog.h>
 #include <psp2/message_dialog.h>
-#include <string.h>
-#include <vita2d.h>
 
 enum {
     IME_DIALOG_RESULT_NONE = 0,
@@ -111,27 +110,20 @@ const uint8_t *vita_keyboard_get(const uint8_t *initial_text, int max_length)
 
     if (ime_init_apputils == 0) {
         sceAppUtilInit(&(SceAppUtilInitParam){}, &(SceAppUtilBootParam){});
-        sceCommonDialogSetConfigParam(&(SceCommonDialogConfigParam){});
         ime_init_apputils = 1;
     }
     init_ime_dialog(initial_text, max_length, SCE_IME_TYPE_BASIC_LATIN, 0);
     int done = 0;
     while (!done) {
-        vita2d_start_drawing();
-        vita2d_clear_screen();
-
+        platform_screen_clear();
         done = 1;
-
         int ime_result = update_ime_dialog();
         if (ime_result == IME_DIALOG_RESULT_FINISHED) {
             encoding_from_utf8(ime_text_utf8, final_text, max_length);
         } else if (ime_result != IME_DIALOG_RESULT_CANCELED) {
             done = 0;
         }
-        vita2d_end_drawing();
-        vita2d_common_dialog_update();
-        vita2d_swap_buffers();
-        sceDisplayWaitVblankStart();
+        platform_screen_render(0);
     }
     return final_text;
 }

--- a/src/platform/vita/vita_keyboard.c
+++ b/src/platform/vita/vita_keyboard.c
@@ -125,7 +125,7 @@ const uint8_t *vita_keyboard_get(const uint8_t *initial_text, int max_length)
         } else if (ime_result != IME_DIALOG_RESULT_CANCELED) {
             done = 0;
         }
-        platform_screen_render(0);
+        platform_screen_render();
     }
     return final_text;
 }

--- a/src/platform/vita/vita_keyboard.c
+++ b/src/platform/vita/vita_keyboard.c
@@ -2,6 +2,7 @@
 
 #include "core/calc.h"
 #include "core/encoding.h"
+#include "core/string.h"
 #include "platform/screen.h"
 
 #include <string.h>
@@ -11,6 +12,7 @@
 #include <psp2/kernel/processmgr.h>
 #include <psp2/ime_dialog.h>
 #include <psp2/message_dialog.h>
+#include <string.h>
 
 enum {
     IME_DIALOG_RESULT_NONE = 0,


### PR DESCRIPTION
Update vita toolchain, which uses a more recent/better integrated SDL build.

Allows getting rid of the `vita2d` hacks and improves performace on Vita by 5% to 10%.