### PR TITLE
Add Haiku OS compatibility

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -106,6 +106,7 @@ ELSE()
         /opt/local # DarwinPorts
         /opt/csw # Blastwave
         /opt
+        /boot/system/develop/headers/SDL2 # Haiku
         ${SDL_EXT_DIR}
         ${SDL_MINGW_EXT_DIR}
         ${CMAKE_FIND_ROOT_PATH}

--- a/cmake/FindSDL2_mixer.cmake
+++ b/cmake/FindSDL2_mixer.cmake
@@ -72,6 +72,7 @@ ELSE()
         /opt/local # DarwinPorts
         /opt/csw # Blastwave
         /opt
+        /boot/system/develop/headers/SDL2 # Haiku
         ${SDL_MIXER_EXT_DIR}
         ${SDL_MINGW_EXT_DIR}
         ${CMAKE_FIND_ROOT_PATH}

--- a/src/core/backtrace.c
+++ b/src/core/backtrace.c
@@ -2,7 +2,7 @@
 
 #include "core/log.h"
 
-#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__)
+#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__) && !defined(__HAIKU__)
 
 #include <execinfo.h>
 

--- a/src/platform/cursor.c
+++ b/src/platform/cursor.c
@@ -6,6 +6,7 @@
 #include "platform/screen.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
+#include "platform/haiku/haiku.h"
 
 #include "SDL.h"
 

--- a/src/platform/cursor.c
+++ b/src/platform/cursor.c
@@ -4,9 +4,9 @@
 #include "graphics/color.h"
 #include "input/cursor.h"
 #include "platform/screen.h"
+#include "platform/haiku/haiku.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
-#include "platform/haiku/haiku.h"
 
 #include "SDL.h"
 

--- a/src/platform/haiku/haiku.h
+++ b/src/platform/haiku/haiku.h
@@ -1,0 +1,9 @@
+#ifndef PLATFORM_HAIKU_H
+#define PLATFORM_HAIKU_H
+
+#ifdef __HAIKU__
+
+#define PLATFORM_USE_SOFTWARE_CURSOR
+
+#endif // __HAIKU__
+#endif // PLATFORM_HAIKU_H

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -9,9 +9,9 @@
 #include "input/cursor.h"
 #include "platform/android/android.h"
 #include "platform/cursor.h"
+#include "platform/haiku/haiku.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
-#include "platform/haiku/haiku.h"
 
 #include "SDL.h"
 

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -11,6 +11,7 @@
 #include "platform/cursor.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
+#include "platform/haiku/haiku.h"
 
 #include "SDL.h"
 


### PR DESCRIPTION
These small changes are all that's required to be able to build and run natively on Haiku with the Haiku-provided SDL2, SDL2_mixer, and libpng libraries.

The only challenge with these changes in place is the cmake command, which can't natively find the SDL2_INCLUDE_DIR and SDL2_MIXER_INCLUDE_DIR. If specified in the CMake command line as -DSDL2_INCLUDE_DIR=/boot/system/develop/headers/SDL2 -DSDL2_MIXER_INCLUDE_DIR=/boot/system/develop/headers/SDL2, then it builds and runs just fine on Haiku R1 beta2.