### PR TITLE
Support High DPI screens

### DIFF
--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -121,6 +121,11 @@ int platform_screen_create(const char *title, int display_scale_percentage)
     SDL_Log("Creating screen %d x %d, %s, driver: %s", width, height,
         fullscreen ? "fullscreen" : "windowed", SDL_GetCurrentVideoDriver());
     Uint32 flags = SDL_WINDOW_RESIZABLE;
+
+#if SDL_VERSION_ATLEAST(2, 0, 1)
+    flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+#endif
+
     if (fullscreen) {
         flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }


### PR DESCRIPTION
This is a very basic implementation of High DPI screen support for Julius. It simply passes the ``SDL_WINDOW_ALLOW_HIGHDPI`` flag to ``SDL_CreateWindow()``.

This means that the OS will still scale window resolutions: so, for example, on a 3200×1800px screen which has an OS scaling factor of 2×, Julius will run fullscreen at what appears to be 1600×900, and the windowed modes will all be scaled 2×. Julius will still show the scale as 100%. Setting the in-game scale to 50% on such a machine will give an actually 3200×1800px display, and it will look much crisper than it would without this change.

The only visible difference will be that the scaling will be smoother, as Julius will be doing all of the scaling work (through
``SDL_RenderSetLogicalSize()``), rather than scaling to a half-resolution buffer, then letting the OS scale it again.

Note that I did look into trying a more complicated implementation which used the actual pixel resolutions everywhere (via ``SDL_GetRendererOutputSize()``, but it got very complicated and buggy, as there's no easy way to get a screen's scaling factor via SDL without having a window and renderer already created. (It also effectively resulted in there being three different coordinate spaces: logical_{width,height}, pixel_{width,height}, and window_{width,height}, with there being no way to resize a window in pixel coordines. Basically, it was a mess.) It did mean that the in-game scale factor was independent of the OS scale factor, though. But if that's a path you'd rather explore, I can keep looking into it.

I've tested this on Linux under X11 (which doesn't support High DPI in SDL, so behaves exactly as before), and Wayland (where it worked fine, behaved as before but looked much smoother if the scale was not an integer multiple of 100%). Both of these tests were under KDE/KWin 5.21.5 on OpenSUSE Tumbleweed.