### PR TITLE
Fix a compile warning in custom_music_callback

### DIFF
--- a/src/platform/sound_device.c
+++ b/src/platform/sound_device.c
@@ -460,7 +460,7 @@ static int get_custom_audio_stream(Uint8 *dst, int len)
 
 static void custom_music_callback(void *dummy, Uint8 *stream, int len)
 {
-    int bytes_copied = get_custom_audio_stream(stream, len);
+    get_custom_audio_stream(stream, len);
 }
 
 void sound_device_use_custom_music_player(int bitdepth, int num_channels, int rate,


### PR DESCRIPTION
The ``custom_music_callback()`` function no longer uses the result from ``get_custom_audio_stream()`` as of commit 14faa68370, leaving the bytes_copied variable unused. (This seems to be because the buffer is now being cleared within ``get_custom_audio_stream()``).

This causes gcc to spit out an unused variable warning:
```
/home/david/Development/julius/src/platform/sound_device.c: In function ‘custom_music_callback’:
/home/david/Development/julius/src/platform/sound_device.c:463:9: warning: unused variable ‘bytes_copied’ [-Wunused-variable]
  463 |     int bytes_copied = get_custom_audio_stream(stream, len);
      |         ^~~~~~~~~~~~
```
Delete the variable (ignoring ``get_custom_audio_stream()``'s return value) to silence the warning.