### PR TITLE
Improve touch scrolling on windows

### DIFF
--- a/src/graphics/rich_text.c
+++ b/src/graphics/rich_text.c
@@ -14,7 +14,10 @@
 
 static void on_scroll(void);
 
-static scrollbar_type scrollbar = {0, 0, 0, on_scroll};
+static scrollbar_type scrollbar = {
+    .has_y_margin = 1,
+    .on_scroll_callback = on_scroll
+};
 
 static struct {
     int message_id;
@@ -57,10 +60,12 @@ int rich_text_init(
         scrollbar.x = data.x_text + BLOCK_SIZE * data.text_width_blocks - 1;
         scrollbar.y = data.y_text;
         scrollbar.height = BLOCK_SIZE * data.text_height_blocks;
-        scrollbar_init(&scrollbar, scrollbar.scroll_position, data.num_lines - data.text_height_lines);
+        scrollbar.elements_in_view = data.text_height_lines;
+        scrollbar_init(&scrollbar, scrollbar.scroll_position, data.num_lines);
         if (data.num_lines <= data.text_height_lines && adjust_width_on_no_scroll) {
             data.text_width_blocks += 2;
         }
+        scrollbar.scrollable_width = BLOCK_SIZE * data.text_width_blocks;
         window_invalidate();
     }
     return data.text_width_blocks;

--- a/src/graphics/scrollbar.h
+++ b/src/graphics/scrollbar.h
@@ -9,22 +9,27 @@ typedef struct {
     int x;
     int y;
     int height;
+    int scrollable_width;
+    int elements_in_view;
     void (*on_scroll_callback)(void);
+    int has_y_margin;
     int dot_padding;
     int always_visible;
     int max_scroll_position;
     int scroll_position;
-    int is_dragging_scroll;
-    int scroll_position_drag;
+    int is_dragging_scrollbar_dot;
+    int scrollbar_dot_drag_offset;
+    int touch_drag_state;
+    int position_on_touch;
 } scrollbar_type;
 
 /**
  * Initializes the scrollbar
  * @param scrollbar Scrollbar
  * @param scroll_position Scroll position to set
- * @param max_scroll_position Max position
+ * @param total_elements The number of elements to scroll
  */
-void scrollbar_init(scrollbar_type *scrollbar, int scroll_position, int max_scroll_position);
+void scrollbar_init(scrollbar_type *scrollbar, int scroll_position, int total_elements);
 
 /**
  * Resets the text to the specified scroll position and forces recalculation of lines
@@ -34,11 +39,11 @@ void scrollbar_init(scrollbar_type *scrollbar, int scroll_position, int max_scro
 void scrollbar_reset(scrollbar_type *scrollbar, int scroll_position);
 
 /**
- * Update the max position, adjusting the scroll position if necessary
+ * Update the number of total elements, adjusting the scroll position if necessary
  * @param scrollbar Scrollbar
- * @param max_scroll_position New max position
+ * @param total_items New number of total elements
  */
-void scrollbar_update_max(scrollbar_type *scrollbar, int max_scroll_position);
+void scrollbar_update_total_elements(scrollbar_type *scrollbar, int total_elements);
 
 /**
  * Draws the scrollbar

--- a/src/window/cck_selection.c
+++ b/src/window/cck_selection.c
@@ -56,7 +56,7 @@ static generic_button file_buttons[] = {
     {18, 444, 252, 16, button_select_item, button_none, 14, 0},
 };
 
-static scrollbar_type scrollbar = {276, 210, 256, on_scroll, 8, 1};
+static scrollbar_type scrollbar = {276, 210, 256, 260, MAX_SCENARIOS, on_scroll, 1, 8, 1};
 
 static struct {
     int focus_button_id;
@@ -77,7 +77,7 @@ static void init(void)
     data.focus_toggle_button = 0;
     data.show_minimap = 0;
     button_select_item(0, 0);
-    scrollbar_init(&scrollbar, 0, data.scenarios->num_files - MAX_SCENARIOS);
+    scrollbar_init(&scrollbar, 0, data.scenarios->num_files);
 }
 
 static void draw_scenario_list(void)

--- a/src/window/config.c
+++ b/src/window/config.c
@@ -57,7 +57,9 @@ static const uint8_t *display_text_language(void);
 static const uint8_t *display_text_display_scale(void);
 static const uint8_t *display_text_cursor_scale(void);
 
-static scrollbar_type scrollbar = {580, ITEM_Y_OFFSET, ITEM_HEIGHT * NUM_VISIBLE_ITEMS, on_scroll, 4};
+static scrollbar_type scrollbar = {
+    580, ITEM_Y_OFFSET, ITEM_HEIGHT * NUM_VISIBLE_ITEMS, CHECKBOX_WIDTH, NUM_VISIBLE_ITEMS, on_scroll, 0, 4
+};
 
 enum {
     TYPE_NONE,
@@ -257,7 +259,7 @@ static void init(void)
     }
     install_widgets();
 
-    scrollbar_init(&scrollbar, 0, data.num_widgets - NUM_VISIBLE_ITEMS);
+    scrollbar_init(&scrollbar, 0, data.num_widgets);
 }
 
 static void checkbox_draw_text(int x, int y, int value_key, translation_key description)

--- a/src/window/file_dialog.c
+++ b/src/window/file_dialog.c
@@ -55,7 +55,7 @@ static generic_button file_buttons[] = {
     {160, 304, 288, 16, button_select_file, button_none, 11, 0},
 };
 
-static scrollbar_type scrollbar = {464, 120, 206, on_scroll};
+static scrollbar_type scrollbar = {464, 120, 206, 320, NUM_FILES_IN_VIEW, on_scroll, 1};
 
 typedef struct {
     char extension[4];
@@ -141,7 +141,7 @@ static void init(file_type type, file_dialog_type dialog_type)
     string_copy(data.typed_name, data.previously_seen_typed_name, FILE_NAME_MAX);
 
     data.file_list = dir_find_files_with_extension(data.file_data->extension);
-    scrollbar_init(&scrollbar, 0, data.file_list->num_files - NUM_FILES_IN_VIEW);
+    scrollbar_init(&scrollbar, 0, data.file_list->num_files);
     scroll_to_typed_text();
 
     strncpy(data.selected_file, data.file_data->last_loaded_file, FILE_NAME_MAX);
@@ -210,10 +210,11 @@ static void handle_input(const mouse *m, const hotkeys *h)
     }
 
     const mouse *m_dialog = mouse_in_dialog(m);
-    if (input_box_handle_mouse(m_dialog, &file_name_input) ||
+    data.focus_button_id = 0;
+    if (scrollbar_handle_mouse(&scrollbar, m_dialog) ||
+        input_box_handle_mouse(m_dialog, &file_name_input) ||
         generic_buttons_handle_mouse(m_dialog, 0, 0, file_buttons, NUM_FILES_IN_VIEW, &data.focus_button_id) ||
-        image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons, 2, 0) ||
-        scrollbar_handle_mouse(&scrollbar, m_dialog)) {
+        image_buttons_handle_mouse(m_dialog, 0, 0, image_buttons, 2, 0)) {
         return;
     }
     if (input_go_back_requested(m, h)) {

--- a/src/window/hotkey_config.c
+++ b/src/window/hotkey_config.c
@@ -31,7 +31,7 @@ static void button_hotkey(int row, int is_alternative);
 static void button_reset_defaults(int param1, int param2);
 static void button_close(int save, int param2);
 
-static scrollbar_type scrollbar = {580, 72, 352, on_scroll};
+static scrollbar_type scrollbar = {580, 72, 352, 560, NUM_VISIBLE_OPTIONS, on_scroll, 1};
 
 typedef struct {
     int action;
@@ -170,7 +170,7 @@ static struct {
 
 static void init(void)
 {
-    scrollbar_init(&scrollbar, 0, sizeof(hotkey_widgets) / sizeof(hotkey_widget) - NUM_VISIBLE_OPTIONS);
+    scrollbar_init(&scrollbar, 0, sizeof(hotkey_widgets) / sizeof(hotkey_widget));
 
     for (int i = 0; i < HOTKEY_MAX_ITEMS; i++) {
         hotkey_mapping empty = {KEY_TYPE_NONE, KEY_MOD_NONE, i};

--- a/src/window/message_dialog.c
+++ b/src/window/message_dialog.c
@@ -508,6 +508,9 @@ static int handle_input_video(const mouse *m_dialog, const lang_message *msg)
 
 static int handle_input_normal(const mouse *m_dialog, const lang_message *msg)
 {
+    if (rich_text_handle_mouse(m_dialog)) {
+        return 1;
+    }
     if (msg->type == TYPE_MANUAL && image_buttons_handle_mouse(
                 m_dialog, data.x + 16, data.y + BLOCK_SIZE * msg->height_blocks - 36, &image_button_back, 1, 0)) {
         return 1;
@@ -531,7 +534,6 @@ static int handle_input_normal(const mouse *m_dialog, const lang_message *msg)
         &image_button_close, 1, 0)) {
         return 1;
     }
-    rich_text_handle_mouse(m_dialog);
     int text_id = rich_text_get_clicked_link(m_dialog);
     if (text_id >= 0) {
         if (data.num_history < MAX_HISTORY - 1) {

--- a/src/window/message_list.c
+++ b/src/window/message_list.c
@@ -44,7 +44,7 @@ static generic_button generic_buttons_messages[] = {
     {0, 180, 412, 18, button_message, button_delete, 9, 0},
 };
 
-static scrollbar_type scrollbar = {432, 112, 208, on_scroll};
+static scrollbar_type scrollbar = {432, 112, 208, 416, MAX_MESSAGES, on_scroll, 1};
 
 static struct {
     int width_blocks;
@@ -60,7 +60,7 @@ static struct {
 static void init(void)
 {
     city_message_sort_and_compact();
-    scrollbar_init(&scrollbar, city_message_scroll_position(), city_message_count() - MAX_MESSAGES);
+    scrollbar_init(&scrollbar, city_message_scroll_position(), city_message_count());
 }
 
 static void draw_background(void)
@@ -146,6 +146,11 @@ static void handle_input(const mouse *m, const hotkeys *h)
     int old_button_id = data.focus_button_id;
     data.focus_button_id = 0;
 
+    if (scrollbar_handle_mouse(&scrollbar, m_dialog)) {
+        data.focus_button_id = 13;
+        return;
+    }
+
     int button_id;
     int handled = image_buttons_handle_mouse(m_dialog, 16, 32 + BLOCK_SIZE * data.height_blocks - 42,
         &image_button_help, 1, &button_id);
@@ -156,9 +161,6 @@ static void handle_input(const mouse *m, const hotkeys *h)
         32 + BLOCK_SIZE * data.height_blocks - 36, &image_button_close, 1, &button_id);
     if (button_id) {
         data.focus_button_id = 12;
-    }
-    if (scrollbar_handle_mouse(&scrollbar, m_dialog)) {
-        data.focus_button_id = 13;
     }
     handled |= generic_buttons_handle_mouse(m_dialog, data.x_text, data.y_text + 4,
         generic_buttons_messages, MAX_MESSAGES, &button_id);
@@ -208,7 +210,7 @@ static void button_delete(int id_to_delete, int param2)
     int id = city_message_set_current(scrollbar.scroll_position + id_to_delete);
     if (id < city_message_count()) {
         city_message_delete(id);
-        scrollbar_update_max(&scrollbar, city_message_count() - MAX_MESSAGES);
+        scrollbar_update_total_elements(&scrollbar, city_message_count());
         window_invalidate();
     }
 }

--- a/src/window/mission_briefing.c
+++ b/src/window/mission_briefing.c
@@ -151,6 +151,9 @@ static void handle_input(const mouse *m, const hotkeys *h)
 {
     const mouse *m_dialog = mouse_in_dialog(m);
 
+    if (rich_text_handle_mouse(m_dialog)) {
+        return;
+    }
     if (image_buttons_handle_mouse(m_dialog, 516, 426, &image_button_start_mission, 1, 0)) {
         return;
     }
@@ -159,7 +162,6 @@ static void handle_input(const mouse *m, const hotkeys *h)
             return;
         }
     }
-    rich_text_handle_mouse(m_dialog);
 }
 
 static void button_back(int param1, int param2)


### PR DESCRIPTION
Allows holding a finger and dragging inside scrollable elements, like a regular scrollable interface using touch.

Hopefully doesn't break regular scrolling.