### PR TITLE
Support macOS 10.4

### DIFF
--- a/src/core/backtrace.c
+++ b/src/core/backtrace.c
@@ -4,7 +4,8 @@
 
 #if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && \
     !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__) && \
-    !defined(__HAIKU__) && !defined(__EMSCRIPTEN__)
+    !defined(__HAIKU__) && !defined(__EMSCRIPTEN__) && \
+    (!defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050)
 
 #include <execinfo.h>
 


### PR DESCRIPTION
macOS 10.4 lacks `execinfo.h`. Adding the proposed logic allows the project to be compiled and the game to be played on this very old platform.

(I have read CONTRIBUTING.md and understand I am supposed to raise an issue first, but it's a small change and this seemed like the easiest way to discuss it.)