### PR TITLE
Fix legion return button on distant battle

### DIFF
--- a/src/window/advisor/military.c
+++ b/src/window/advisor/military.c
@@ -132,7 +132,7 @@ static int draw_background(void)
         image_draw(image_id, 403, 86 + 44 * i);
 
         button_border_draw(480, 83 + 44 * i, 30, 30, 0);
-        if (m->is_at_fort) {
+        if (m->is_at_fort || m->in_distant_battle) {
             image_draw(image_id + 2, 483, 86 + 44 * i);
         } else {
             image_draw(image_id + 1, 483, 86 + 44 * i);

--- a/src/window/building/military.c
+++ b/src/window/building/military.c
@@ -357,7 +357,7 @@ void window_building_draw_legion_info_foreground(building_info_context *c)
     lang_text_draw_multiline(138, text_id, c->x_offset + 24, c->y_offset + 252,
         BLOCK_SIZE * (c->width_blocks - 4), FONT_NORMAL_GREEN);
 
-    if (!m->is_at_fort) {
+    if (!m->is_at_fort && !m->in_distant_battle) {
         button_border_draw(c->x_offset + BLOCK_SIZE * (c->width_blocks - 18) / 2,
             c->y_offset + BLOCK_SIZE * c->height_blocks - 48, 288, 32, data.return_button_id == 1);
         lang_text_draw_centered(138, 58, c->x_offset + BLOCK_SIZE * (c->width_blocks - 18) / 2,


### PR DESCRIPTION
Don't draw the "Return to fort" button on the legion info screen when
legion is leaving the city for a distant battle.
Draw the correct thumbnail for the advisor "Return to fort" button when
legion is leaving/has left the city for a distant battle.