### PR TITLE
Out of bounds memory read/write bugs during invasions

### DIFF
--- a/src/figure/formation_enemy.c
+++ b/src/figure/formation_enemy.c
@@ -480,6 +480,7 @@ static void update_enemy_movement(formation *m, int roman_distance)
             army->home_x;
         int y_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][2 * m->enemy_legion_index + 1] +
             army->home_y;
+        map_grid_bound(&x_offset, &y_offset);
         int x_tile, y_tile;
         if (formation_enemy_move_formation_to(m, x_offset, y_offset, &x_tile, &y_tile)) {
             formation_set_destination(m, x_tile, y_tile);
@@ -490,6 +491,7 @@ static void update_enemy_movement(formation *m, int roman_distance)
             army->destination_x;
         int y_offset = LAYOUT_ORIENTATION_OFFSETS[layout][m->orientation / 2][2 * m->enemy_legion_index + 1] +
             army->destination_y;
+        map_grid_bound(&x_offset, &y_offset);
         int x_tile, y_tile;
         if (formation_enemy_move_formation_to(m, x_offset, y_offset, &x_tile, &y_tile)) {
             formation_set_destination(m, x_tile, y_tile);

--- a/src/figure/formation_layout.c
+++ b/src/figure/formation_layout.c
@@ -35,10 +35,10 @@ static const int FORMATION_LAYOUT_POSITION_Y[FORMATION_MAX][MAX_FORMATION_FIGURE
 
 int formation_layout_position_x(int layout, int index)
 {
-    return FORMATION_LAYOUT_POSITION_X[layout][index];
+    return FORMATION_LAYOUT_POSITION_X[layout][index % MAX_FORMATION_FIGURES];
 }
 
 int formation_layout_position_y(int layout, int index)
 {
-    return FORMATION_LAYOUT_POSITION_Y[layout][index];
+    return FORMATION_LAYOUT_POSITION_Y[layout][index % MAX_FORMATION_FIGURES];
 }

--- a/src/map/figure.c
+++ b/src/map/figure.c
@@ -14,6 +14,13 @@ int map_figure_at(int grid_offset)
     return map_grid_is_valid_offset(grid_offset) ? figures.items[grid_offset] : 0;
 }
 
+static void cap_figures_on_same_tile_index(figure *f)
+{
+    if (f->figures_on_same_tile_index > 20) {
+        f->figures_on_same_tile_index = 20;
+    }
+}
+
 void map_figure_add(figure *f)
 {
     if (!map_grid_is_valid_offset(f->grid_offset)) {
@@ -29,9 +36,7 @@ void map_figure_add(figure *f)
             next = figure_get(next->next_figure_id_on_same_tile);
             f->figures_on_same_tile_index++;
         }
-        if (f->figures_on_same_tile_index > 20) {
-            f->figures_on_same_tile_index = 20;
-        }
+        cap_figures_on_same_tile_index(f);
         next->next_figure_id_on_same_tile = f->id;
     } else {
         figures.items[f->grid_offset] = f->id;
@@ -48,14 +53,13 @@ void map_figure_update(figure *f)
     figure *next = figure_get(figures.items[f->grid_offset]);
     while (next->id) {
         if (next->id == f->id) {
+            cap_figures_on_same_tile_index(f);
             return;
         }
         f->figures_on_same_tile_index++;
         next = figure_get(next->next_figure_id_on_same_tile);
     }
-    if (f->figures_on_same_tile_index > 20) {
-        f->figures_on_same_tile_index = 20;
-    }
+    cap_figures_on_same_tile_index(f);
 }
 
 void map_figure_delete(figure *f)


### PR DESCRIPTION
These can all be reproduced with the -fsanitize=undefined flag on shortly after the invasion starts in the attached save.

[Invasion Test OG.zip](https://github.com/bvschaik/julius/files/10191500/Invasion.Test.OG.zip)