### PR TITLE
Use -fsanitize=undefined when compiling with Clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ if (CMAKE_COMPILER_IS_GNUCC)
     if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 5.0)
         set(CMAKE_C_FLAGS "-Werror=incompatible-pointer-types -Werror=int-conversion -Wstrict-prototypes ${CMAKE_C_FLAGS}")
     endif()
+elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined")
 endif()
 
 set(PROJECT_VERSION_MAJOR 1)


### PR DESCRIPTION
I tried upgrading to VS 2022 and it stopped reporting every single for loop as an error, so I propose we go ahead and set this flag by default when in Debug mode. Might want to do it for GCC as well.