### PR TITLE
Add /utf-8 for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,7 +658,6 @@ endif()
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
-    # add_compile_options(/utf-8)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,8 @@ endif()
 
 if(MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+    # add_compile_options(/utf-8)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8")
 endif()
 
 if(APPLE)

--- a/ext/png/png.h
+++ b/ext/png/png.h
@@ -19,7 +19,7 @@
  *     Cosmin Truta
  *   See also "Contributing Authors", below.
  *
- * Changed for Julius by José Cadete (crudelios) on 11 Feb 2020.
+ * Changed for Julius by JosÃ© Cadete (crudelios) on 11 Feb 2020.
  * The library was heavily trimmed, with many files or unused code/comments
  * removed and compiler settings disabled to make it lightweight.
  * Therefore, do not use this version in your projects.

--- a/ext/zlib/zlib.h
+++ b/ext/zlib/zlib.h
@@ -27,7 +27,7 @@
   Comments) 1950 to 1952 in the files http://tools.ietf.org/html/rfc1950
   (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
 
-  Changed for Julius by José Cadete (crudelios) on 11 Feb 2020.
+  Changed for Julius by JosÃ© Cadete (crudelios) on 11 Feb 2020.
   The library was heavily trimmed, with many files removed or reduced to make
   it lightweight. Therefore, do not use this version in your projects.
 */


### PR DESCRIPTION
Some compile error on non-English MSVC:
```
2>------ Rebuild All started: Project: julius, Configuration: Debug x64 ------
...
2>japanese.c
2>D:\prj\julius\src\translation\japanese.c(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss
2>D:\prj\julius\src\translation\japanese.c(9,9): error C2001: newline in constant
2>D:\prj\julius\src\translation\japanese.c(11,5): error C2059: syntax error: '{'
...
2>korean.c
2>D:\prj\julius\src\translation\korean.c(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss
2>D:\prj\julius\src\translation\korean.c(29,32): error C2001: newline in constant
2>D:\prj\julius\src\translation\korean.c(30,5): error C2059: syntax error: '{'
...
2>simplified_chinese.c
2>D:\prj\julius\src\translation\simplified_chinese.c(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss
2>D:\prj\julius\src\translation\simplified_chinese.c(7,9): error C2001: newline in constant
2>D:\prj\julius\src\translation\simplified_chinese.c(10,9): error C2001: newline in constant
```
"/utf-8" in *.vcxproj files can fix it like:
```
<AdditionalOptions>%(AdditionalOptions) /utf-8</AdditionalOptions>
```
Anyway, CMake add_compile_options() didn't work as expected, thus a CMAKE_C_FLAGS workaround is used in this PR.

FYI: 
[/utf-8](https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170)
[add_compile_options](https://cmake.org/cmake/help/latest/command/add_compile_options.html)