### PR TITLE
Add LTCG support for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.9)
+include(CheckIPOSupported)
 include(CMakeDependentOption)
 
 set(TARGET_PLATFORM "default" CACHE STRING "Platform to cross-compile for. Options: vita switch android emscripten. Leave blank for no cross compilation")
@@ -657,6 +658,11 @@ if(${TARGET_PLATFORM} STREQUAL "emscripten")
 endif()
 
 if(MSVC)
+    cmake_policy(SET CMP0069 NEW)
+    check_ipo_supported(RESULT result)
+    if(result)
+        set_property(TARGET julius PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 


### PR DESCRIPTION
libpng16.lib for x64 platform (Copy settings from Win32 in MSVC Configuration Manager) will use /GL option for LTCG by default.
It causes some LTCG message:
```
2>------ Rebuild All started: Project: julius, Configuration: Release x64 ------
...
2>editor.c
2>libpng16.lib(pngwrite.obj) : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
```

This PR is to get julius ready for MSVC x64 platform.

Check "cmake.exe --help-policy CMP0069" output too.

FYI:
[CheckIPOSupported](https://cmake.org/cmake/help/latest/module/CheckIPOSupported.html)
[IPO: INTERPROCEDURAL_OPTIMIZATION (LTCG) for VS](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/2363)
