### PR TITLE
Add dump_lang_data() to log translated texts and messages

### DIFF
--- a/src/core/lang.c
+++ b/src/core/lang.c
@@ -1,12 +1,14 @@
 #include "core/lang.h"
 
 #include "core/buffer.h"
+#include "core/encoding.h"
 #include "core/file.h"
 #include "core/io.h"
 #include "core/string.h"
 
 #include <stdlib.h>
 #include <string.h>
+#include <SDL.h>
 
 #define MAX_TEXT_ENTRIES 1000
 #define MAX_TEXT_DATA 200000
@@ -37,6 +39,49 @@ static struct {
     lang_message message_entries[MAX_MESSAGE_ENTRIES];
     uint8_t message_data[MAX_MESSAGE_DATA];
 } data;
+
+void dump_lang_data(void)
+{
+    int decomposed = encoding_system_uses_decomposed();
+    char buf[1024 * 10];
+    uint8_t *p;
+
+    SDL_Log("Lang text_data entries:");
+    for (int i = 0; i < MAX_TEXT_ENTRIES; ++i) {
+        if (data.text_entries[i].in_use) {
+            buf[0] = 0;
+            encoding_to_utf8(data.text_data + data.text_entries[i].offset, buf, sizeof(buf), decomposed);
+            SDL_Log("%d: %s", i, buf);
+        }
+    }
+    SDL_Log("Lang message_data entries:");
+    for (int i = 0; i < MAX_MESSAGE_ENTRIES; ++i) {
+        buf[0] = 0;
+        p = data.message_entries[i].title.text;
+        if (p) {
+            encoding_to_utf8(p, buf, sizeof(buf), decomposed);
+            SDL_Log("%d: %s", i, buf);
+        }
+        buf[0] = 0;
+        p = data.message_entries[i].subtitle.text;
+        if (p) {
+            encoding_to_utf8(p, buf, sizeof(buf), decomposed);
+            SDL_Log("    subtitle: %s", buf);
+        }
+        buf[0] = 0;
+        p = data.message_entries[i].video.text;
+        if (p) {
+            encoding_to_utf8(p, buf, sizeof(buf), decomposed);
+            SDL_Log("    video: %s", buf);
+        }
+        buf[0] = 0;
+        p = data.message_entries[i].content.text;
+        if (p) {
+            encoding_to_utf8(p, buf, sizeof(buf), decomposed);
+            SDL_Log("    content: %s", buf);
+        }
+    }
+}
 
 static int file_exists_in_dir(const char *dir, const char *file)
 {

--- a/src/core/lang.h
+++ b/src/core/lang.h
@@ -69,6 +69,11 @@ typedef struct {
 } lang_message;
 
 /**
+ * Dump preloaded lang data
+ */
+void dump_lang_data(void);
+
+/**
  * Checks whether the directory contains language files
  * @param dir Directory to check
  * @return boolean true if it contains language files, false if not

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -130,6 +130,7 @@ static int reload_language(int is_editor, int reload_images)
         errlog("unable to load main graphics");
         return 0;
     }
+    dump_lang_data();
     return 1;
 }
 

--- a/test/stub/lang.c
+++ b/test/stub/lang.c
@@ -5,6 +5,10 @@ static uint8_t EMPTY[] = {0};
 
 static lang_message msg;
 
+void dump_lang_data(void)
+{
+}
+
 int lang_load(int is_editor)
 {
     return 1;


### PR DESCRIPTION
This PR add a debug helper function: dump_lang_data.
It logs src/core/lang.c data content to help checking texts and messages validity.
It's called only when you change the language setting in the Options menu, thus the log won't appear normally.

It helps #689 to identify corrupted/duplicate/empty translation text and messages.