### PR TITLE
Increase warnings for julius

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,14 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/")
 
 set(CMAKE_C_STANDARD 99)
 
-if (CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror=implicit-function-declaration")
+if(CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare -Werror=implicit-function-declaration")
     if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 5.0)
         set(CMAKE_C_FLAGS "-Werror=incompatible-pointer-types -Werror=int-conversion -Wstrict-prototypes ${CMAKE_C_FLAGS}")
+    endif()
+
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
+        set(CMAKE_C_FLAGS "-Walloc-zero -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wformat=2 -Wformat-signedness -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wshadow -Wundef -Wunused-macros -Wwrite-strings ${CMAKE_C_FLAGS}")
     endif()
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_BUILD_TYPE}" MATCHES "Debug" AND NOT ${TARGET_PLATFORM} STREQUAL "android")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined")
@@ -724,33 +728,34 @@ if(APPLE)
 endif()
 
 if(SDL2_INCLUDE_DIR)
-    include_directories(${SDL2_INCLUDE_DIR})
+    include_directories(SYSTEM ${SDL2_INCLUDE_DIR})
 endif()
 if(SDL2_MIXER_INCLUDE_DIR)
-    include_directories(${SDL2_MIXER_INCLUDE_DIR})
+    include_directories(SYSTEM ${SDL2_MIXER_INCLUDE_DIR})
 endif()
 
 if(SYSTEM_LIBS)
     find_package(PNG)
 endif()
 if(PNG_FOUND)
-    include_directories(${PNG_INCLUDE_DIRS})
+    include_directories(SYSTEM ${PNG_INCLUDE_DIRS})
     target_link_libraries(${SHORT_NAME} ${PNG_LIBRARIES})
 else()
     if(SYSTEM_LIBS)
         message(STATUS "PNG was not found but that's ok: falling back to internal version")
     endif()
-    include_directories("ext/png")
+
+    include_directories(SYSTEM "ext/png")
     target_sources(${SHORT_NAME} PRIVATE "${PNG_FILES}" "${ZLIB_FILES}")
 endif()
 
 if(${TARGET_PLATFORM} STREQUAL "vita")
-    include_directories(
+    include_directories(SYSTEM
         $ENV{VITASDK}/arm-vita-eabi/include
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 elseif (${TARGET_PLATFORM} STREQUAL "switch")
-    include_directories(
+    include_directories(SYSTEM
         ${DEVKITPRO}/portlibs/switch/include/SDL2
         ${DEVKITPRO}/libnx/include
         ${DEVKITPRO}/portlibs/switch/include
@@ -758,10 +763,10 @@ elseif (${TARGET_PLATFORM} STREQUAL "switch")
     )
 endif()
 
-include_directories(ext)
+include_directories(SYSTEM ext)
 include_directories(src)
 if(MSVC)
-    include_directories(ext/dirent)
+    include_directories(SYSTEM ext/dirent)
 endif()
 
 if (${TARGET_PLATFORM} STREQUAL "vita")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     endif()
 
     if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
-        set(CMAKE_C_FLAGS "-Walloc-zero -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wformat=2 -Wformat-signedness -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wshadow -Wundef -Wunused-macros -Wwrite-strings ${CMAKE_C_FLAGS}")
+        set(CMAKE_C_FLAGS "-Walloc-zero -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wformat=2 -Wformat-signedness -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wundef -Wunused-macros -Wwrite-strings ${CMAKE_C_FLAGS}")
     endif()
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND "${CMAKE_BUILD_TYPE}" MATCHES "Debug" AND NOT ${TARGET_PLATFORM} STREQUAL "android")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined")


### PR DESCRIPTION
This adds some GCC configurations to display more warnings.

These extra warnings helped me fix some bugs in Augustus, maybe they'll be useful for Julius as well.

Note: after enabling the new warnings, a full compilation triggers 93 warnings on mingw, some of them related to our external libs.