### PR TITLE
Haiku OS: Remove no longer needed Haiku-specific header

### DIFF
--- a/src/platform/cursor.c
+++ b/src/platform/cursor.c
@@ -4,7 +4,6 @@
 #include "graphics/color.h"
 #include "input/cursor.h"
 #include "platform/screen.h"
-#include "platform/haiku/haiku.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
 

--- a/src/platform/haiku/haiku.h
+++ b/src/platform/haiku/haiku.h
@@ -1,9 +1,0 @@
-#ifndef PLATFORM_HAIKU_H
-#define PLATFORM_HAIKU_H
-
-#ifdef __HAIKU__
-
-#define PLATFORM_USE_SOFTWARE_CURSOR
-
-#endif // __HAIKU__
-#endif // PLATFORM_HAIKU_H

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -9,7 +9,6 @@
 #include "input/cursor.h"
 #include "platform/android/android.h"
 #include "platform/cursor.h"
-#include "platform/haiku/haiku.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
 


### PR DESCRIPTION
Previously I had created a Haiku-specific header file that only specified that SDL2 should use a software cursor.

Patches to the Haiku port of SDL2 have since rendered this unnecessary, so remove the header and all references to it. Hardware cursors works now, as on other platforms.

See https://discourse.libsdl.org/t/sdl-sdl-updated-patches-for-haiku/30888 for the SDL2 changes.