### PR TITLE
Adding some pseudo-random noise into roaming.

### DIFF
--- a/src/figure/movement.c
+++ b/src/figure/movement.c
@@ -17,6 +17,8 @@
 #include "map/routing_terrain.h"
 #include "map/terrain.h"
 
+static short global_roaming_noise = 0;
+
 static void advance_tick(figure *f)
 {
     switch (f->direction) {
@@ -435,7 +437,7 @@ void figure_movement_roam_ticks(figure *f, int num_ticks)
                     if (f->direction < 0) f->direction = 6;
                 } while (dir++ < 4);
             } else { // > 2 road tiles
-                f->direction = (f->roam_random_counter + map_random_get(f->grid_offset)) & 6;
+                f->direction = (++global_roaming_noise + f->roam_random_counter + map_random_get(f->grid_offset)) & 6;
                 if (!road_tiles[f->direction] || f->direction == came_from_direction) {
                     f->roam_ticks_until_next_turn--;
                     if (f->roam_ticks_until_next_turn <= 0) {


### PR DESCRIPTION
The issue:
It is VERY easy to create situations where roaming figures will always choose the same turns and never visit other areas. But the code and all the forums tell it should be done randomly. But it is deterministic.

Every turn is determined by three things: location of the building, location of the figure and distance it made so far. As you may see, all these things are constant for every figure at every point in time. It may look that figure does change decisions, but in fact there's just 4 patterns that every figure repeats again and again. They are like Neo from matrix that is given a choice, not knowing the answer is predetermined.
Moreover, you may have a really lucky seed and all your roamers cover the city pretty well, but after a reload it will change and things may fall apart.

My proposal doesn't use real randoms, it is still a deterministic approach. But in this case the number of factors increase dramatically. Basically every other figure in the game contributes to turn decision. It's like a butterfly effect and should be a great boost for roamers' free will.

P.S. I'm not a C programmer, and assume my code may be wrong, especially I'm not sure about two things:
- is declaring a global variable ok?
- I rely on integer overflow. I assume there's no error/exception if overflowing an integer in C?