### PR TITLE
Enhancement for sidebar unemployment

### DIFF
--- a/src/city/data_private.h
+++ b/src/city/data_private.h
@@ -183,6 +183,7 @@ extern struct city_data_t {
         int32_t graph_order;
     } population;
     struct {
+        int32_t all_have_workers;
         int32_t wages;
         int32_t wages_rome;
         int32_t workers_available;

--- a/src/city/labor.c
+++ b/src/city/labor.c
@@ -55,6 +55,11 @@ static struct {
     {LABOR_CATEGORY_GOVERNANCE_RELIGION, 1},
 };
 
+int city_labor_all_have_workers(void)
+{
+    return city_data.labor.all_have_workers;
+}
+
 int city_labor_unemployment_percentage(void)
 {
     return city_data.labor.unemployment_percentage;
@@ -364,6 +369,8 @@ static void allocate_workers_to_non_water_buildings(void)
             city_data.labor.categories[i].workers_allocated < city_data.labor.categories[i].workers_needed
             ? 1 : 0;
     }
+    // if all buildings, which should have workers, do have
+    city_data.labor.all_have_workers = 1;
     for (int i = 1; i < MAX_BUILDINGS; i++) {
         building *b = building_get(i);
         if (b->state != BUILDING_STATE_IN_USE) {
@@ -392,6 +399,9 @@ static void allocate_workers_to_non_water_buildings(void)
             } else {
                 b->num_workers = required_workers;
             }
+        }
+        if (b->num_workers <= 0) {
+            city_data.labor.all_have_workers = 0;
         }
     }
     for (int i = 0; i < MAX_CATS; i++) {

--- a/src/city/labor.h
+++ b/src/city/labor.h
@@ -9,6 +9,8 @@ typedef struct {
     int total_houses_covered;
 } labor_category_data;
 
+int city_labor_all_have_workers(void);
+
 int city_labor_unemployment_percentage(void);
 int city_labor_unemployment_percentage_for_senate(void);
 

--- a/src/widget/sidebar/extra.c
+++ b/src/widget/sidebar/extra.c
@@ -42,6 +42,7 @@ static struct {
     int is_collapsed;
     sidebar_extra_display info_to_display;
     int game_speed;
+    int all_have_workers;
     int unemployment_percentage;
     int unemployment_amount;
     objective culture;
@@ -145,6 +146,7 @@ static int update_extra_info(int is_background)
         changed |= update_extra_info_value(setting_game_speed(), &data.game_speed);
     }
     if (data.info_to_display & SIDEBAR_EXTRA_DISPLAY_UNEMPLOYMENT) {
+        changed |= update_extra_info_value(city_labor_all_have_workers(), &data.all_have_workers);
         changed |= update_extra_info_value(city_labor_unemployment_percentage(), &data.unemployment_percentage);
         changed |= update_extra_info_value(
                        city_labor_workers_unemployed() - city_labor_workers_needed(),
@@ -212,7 +214,7 @@ static void draw_extra_info_panel(void)
     if (data.info_to_display & SIDEBAR_EXTRA_DISPLAY_UNEMPLOYMENT) {
         y_current_line += EXTRA_INFO_VERTICAL_PADDING;
 
-        lang_text_draw(68, 148, data.x_offset + 10, y_current_line, FONT_NORMAL_WHITE);
+        lang_text_draw(68, 148, data.x_offset + 10, y_current_line, data.all_have_workers ? FONT_NORMAL_WHITE : FONT_NORMAL_GREEN);
         y_current_line += EXTRA_INFO_LINE_SPACE;
 
         int text_width = text_draw_percentage(data.unemployment_percentage,


### PR DESCRIPTION
This is a UI enhancement suggestion.
It is very timing critical to build structures.
A safe way to do so is to build the structure when there are enough jobless workers for it.
However, the unemployment amount, shown in the sidebar, does not fit this need very well.
The labor seekers need some time covering his service to the houses; thus, the unemployment amount is not a good indicator for consecutively building new structures.
To solve this problem, I present this modification: to show the unemployment rate title in different color, indicating whether all buildings that should have workers allocated do have them.