### PR TITLE
Add extra display cmdline options

### DIFF
--- a/src/platform/arguments.c
+++ b/src/platform/arguments.c
@@ -5,6 +5,7 @@
 #define CURSOR_SCALE_ERROR_MESSAGE "Option --cursor-scale must be followed by a scale value of 1, 1.5 or 2"
 #define DISPLAY_SCALE_ERROR_MESSAGE "Option --display-scale must be followed by a scale value between 0.5 and 5"
 #define WINDOWED_AND_FULLSCREEN_ERROR_MESSAGE "Option --windowed and --fullscreen cannot both be specified"
+#define DISPLAY_ID_ERROR_MESSAGE "Option --display must be followed by a number indicating the display, starting from 0"
 #define UNKNOWN_OPTION_ERROR_MESSAGE "Option %s not recognized"
 
 static int parse_decimal_as_percentage(const char *str)
@@ -55,6 +56,7 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
     output_args->cursor_scale_percentage = 0;
     output_args->force_windowed = 0;
     output_args->force_fullscreen = 0;
+    output_args->display_id = 0;
 
     for (int i = 1; i < argc; i++) {
         // we ignore "-psn" arguments, this is needed to launch the app
@@ -91,6 +93,14 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
                 SDL_Log(CURSOR_SCALE_ERROR_MESSAGE);
                 ok = 0;
             }
+        } else if (SDL_strcmp(argv[i], "--display") == 0) {
+            if (i + 1 < argc) {
+                output_args->display_id = SDL_strtol(argv[i + 1], 0, 10);
+                i++;
+            } else {
+                SDL_Log(DISPLAY_ID_ERROR_MESSAGE);
+                ok = 0;
+            }
         } else if (SDL_strcmp(argv[i], "--windowed") == 0) {
             output_args->force_windowed = 1;
         } else if (SDL_strcmp(argv[i], "--fullscreen") == 0) {
@@ -120,6 +130,8 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
         SDL_Log("          Forces the game to start in windowed mode");
         SDL_Log("--fullscreen");
         SDL_Log("          Forces the game to start fullscreen");
+        SDL_Log("--display ID");
+        SDL_Log("          Forces the game to start on the specified display, numbered from 0");
         SDL_Log("The last argument, if present, is interpreted as data directory for the Caesar 3 installation");
     }
     return ok;

--- a/src/platform/arguments.c
+++ b/src/platform/arguments.c
@@ -4,6 +4,7 @@
 
 #define CURSOR_SCALE_ERROR_MESSAGE "Option --cursor-scale must be followed by a scale value of 1, 1.5 or 2"
 #define DISPLAY_SCALE_ERROR_MESSAGE "Option --display-scale must be followed by a scale value between 0.5 and 5"
+#define WINDOWED_AND_FULLSCREEN_ERROR_MESSAGE "Option --windowed and --fullscreen cannot both be specified"
 #define UNKNOWN_OPTION_ERROR_MESSAGE "Option %s not recognized"
 
 static int parse_decimal_as_percentage(const char *str)
@@ -53,6 +54,7 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
     output_args->display_scale_percentage = 0;
     output_args->cursor_scale_percentage = 0;
     output_args->force_windowed = 0;
+    output_args->force_fullscreen = 0;
 
     for (int i = 1; i < argc; i++) {
         // we ignore "-psn" arguments, this is needed to launch the app
@@ -91,6 +93,8 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
             }
         } else if (SDL_strcmp(argv[i], "--windowed") == 0) {
             output_args->force_windowed = 1;
+        } else if (SDL_strcmp(argv[i], "--fullscreen") == 0) {
+            output_args->force_fullscreen = 1;
         } else if (SDL_strcmp(argv[i], "--help") == 0) {
             ok = 0;
         } else if (SDL_strncmp(argv[i], "--", 2) == 0) {
@@ -99,6 +103,10 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
         } else {
             output_args->data_directory = argv[i];
         }
+    }
+    if (output_args->force_fullscreen && output_args->force_windowed) {
+        SDL_Log(WINDOWED_AND_FULLSCREEN_ERROR_MESSAGE);
+        ok = 0;
     }
 
     if (!ok) {
@@ -110,6 +118,8 @@ int platform_parse_arguments(int argc, char **argv, julius_args *output_args)
         SDL_Log("          Scales the mouse cursor by a factor of NUMBER. Number can be 1, 1.5 or 2");
         SDL_Log("--windowed");
         SDL_Log("          Forces the game to start in windowed mode");
+        SDL_Log("--fullscreen");
+        SDL_Log("          Forces the game to start fullscreen");
         SDL_Log("The last argument, if present, is interpreted as data directory for the Caesar 3 installation");
     }
     return ok;

--- a/src/platform/arguments.h
+++ b/src/platform/arguments.h
@@ -7,6 +7,7 @@ typedef struct {
     int cursor_scale_percentage;
     int force_windowed;
     int force_fullscreen;
+    int display_id;
 } julius_args;
 
 int platform_parse_arguments(int argc, char **argv, julius_args *output_args);

--- a/src/platform/arguments.h
+++ b/src/platform/arguments.h
@@ -6,6 +6,7 @@ typedef struct {
     int display_scale_percentage;
     int cursor_scale_percentage;
     int force_windowed;
+    int force_fullscreen;
 } julius_args;
 
 int platform_parse_arguments(int argc, char **argv, julius_args *output_args);

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -559,7 +559,7 @@ static void setup(const julius_args *args)
 
     char title[100];
     encoding_to_utf8(lang_get_string(9, 0), title, 100, 0);
-    if (!platform_screen_create(title, config_get(CONFIG_SCREEN_DISPLAY_SCALE))) {
+    if (!platform_screen_create(title, config_get(CONFIG_SCREEN_DISPLAY_SCALE), args->display_id)) {
         SDL_Log("Exiting: SDL create window failed");
         exit_with_status(-2);
     }

--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -544,6 +544,10 @@ static void setup(const julius_args *args)
         setting_set_display(0, w, h);
         SDL_Log("Forcing windowed mode with size %d x %d", w, h);
     }
+    if (args->force_fullscreen && !setting_fullscreen()) {
+        setting_set_display(1, 0, 0);
+        SDL_Log("Forcing fullscreen mode");
+    }
 
     // handle arguments
     if (args->display_scale_percentage) {

--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -97,7 +97,7 @@ static void set_scale_percentage(int new_scale, int pixel_width, int pixel_heigh
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scale_quality);
 }
 
-int platform_screen_create(const char *title, int display_scale_percentage)
+int platform_screen_create(const char *title, int display_scale_percentage, int display_id)
 {
 #ifdef __ANDROID__
     scale.screen_density = android_get_screen_density();
@@ -126,7 +126,11 @@ int platform_screen_create(const char *title, int display_scale_percentage)
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
 #endif
 
-    SDL_Log("Creating screen %d x %d, %s, driver: %s", width, height,
+    if (display_id < 0 || display_id >= SDL_GetNumVideoDisplays()) {
+        SDL_Log("Defaulting to display 0 instead of %d (num displays: %d)", display_id, SDL_GetNumVideoDisplays());
+        display_id = 0;
+    }
+    SDL_Log("Creating screen %d x %d on display %d, %s, driver: %s", width, height, display_id,
         fullscreen ? "fullscreen" : "windowed", SDL_GetCurrentVideoDriver());
     Uint32 flags = SDL_WINDOW_RESIZABLE;
 
@@ -138,7 +142,7 @@ int platform_screen_create(const char *title, int display_scale_percentage)
         flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
     }
     SDL.window = SDL_CreateWindow(title,
-        SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED_DISPLAY(display_id), SDL_WINDOWPOS_CENTERED_DISPLAY(display_id),
         width, height, flags);
 
     if (!SDL.window) {

--- a/src/platform/screen.h
+++ b/src/platform/screen.h
@@ -4,7 +4,7 @@
 #include "graphics/color.h"
 #include "input/cursor.h"
 
-int platform_screen_create(const char *title, int dispay_scale_percentage);
+int platform_screen_create(const char *title, int dispay_scale_percentage, int display_id);
 void platform_screen_destroy(void);
 
 int platform_screen_resize(int pixel_width, int pixel_height);


### PR DESCRIPTION
Add the following command line options:

- `--fullscreen` to start the game fullscreen
- `--display ID` to start the game on the specified display. ID starts counting from 0.

Fixes #716 #717 