### PR TITLE
Fix a printf format string signedness warning

### DIFF
--- a/src/platform/julius.c
+++ b/src/platform/julius.c
@@ -244,11 +244,11 @@ static void handle_window_event(SDL_WindowEvent *event, int *window_active)
             break;
 
         case SDL_WINDOWEVENT_SHOWN:
-            SDL_Log("Window %d shown", (unsigned int) event->windowID);
+            SDL_Log("Window %u shown", (unsigned int) event->windowID);
             *window_active = 1;
             break;
         case SDL_WINDOWEVENT_HIDDEN:
-            SDL_Log("Window %d hidden", (unsigned int) event->windowID);
+            SDL_Log("Window %u hidden", (unsigned int) event->windowID);
             *window_active = 0;
             break;
     }


### PR DESCRIPTION
gcc 13.2 outputs several warnings for mismatched printf format strings, such as:

```
/home/david/Development/julius/test/sav/sav_compare.c: In function ‘compare_part’: /home/david/Development/julius/test/sav/sav_compare.c:522:45: warning: format ‘%X’ expects argument of type ‘unsigned int’, but argument 3 has type ‘int’ [-Wformat=]
  522 |                 printf("record %d offset 0x%X", i / save_game_parts[index].record_length, i % save_game_parts[index].record_length);
      |                                            ~^                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |                                               |
      |                                             unsigned int                                    int
      |                                            %X
```

This patch doesn't fix all of them, but does fix the simple ones. The more complicated ones include signedness issues with '%X' in  the sav_compare test, which would either require a rework of the signedness of a whole bunch of code, or a hacky cast:
```
/home/david/Development/julius/test/sav/sav_compare.c: In function ‘compare_part’:
/home/david/Development/julius/test/sav/sav_compare.c:522:45: warning: format ‘%X’ expects argument of type ‘unsigned int’, but argument 3 has type ‘int’ [-Wformat=]
  522 |                 printf("record %d offset 0x%X", i / save_game_parts[index].record_length, i % save_game_parts[index].record_length);
      |                                            ~^                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                             |                                               |
      |                                             unsigned int                                    int
      |                                            %X
```

There's also a warning about the format string not being a literal in the screenshot code, which would probably require a more clever fix:
```
/home/david/Development/julius/src/graphics/screenshot.c: In function ‘generate_filename’:
/home/david/Development/julius/src/graphics/screenshot.c:103:55: warning: format not a string literal, format string not checked [-Wformat-nonliteral]
  103 |     strftime(filename, FILE_NAME_MAX, filename_formats[city_screenshot], loctime);
      |                                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

All of these are pretty harmless, so it's not particularly important that all (or any) of them actually get fixed. But it's nice to remove a warning if we can. :-)