### PR TITLE
flatpak: Use the local directory to build

### DIFF
--- a/com.github.bvschaik.julius.json
+++ b/com.github.bvschaik.julius.json
@@ -18,9 +18,8 @@
             "buildsystem" : "cmake-ninja",
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/bvschaik/julius.git",
-                    "branch" : "master"
+                    "type" : "dir",
+                    "path" : "."
                 }
             ]
         }


### PR DESCRIPTION
Allows to use any commit that is already checked-out in the current directory.