### PR TITLE
Update lang.c

### DIFF
--- a/src/core/lang.c
+++ b/src/core/lang.c
@@ -26,6 +26,8 @@
 #define FILE_MM_RUS "c3_mm.rus"
 #define FILE_EDITOR_TEXT_ENG "c3_map.eng"
 #define FILE_EDITOR_MM_ENG "c3_map_mm.eng"
+#define FILE_EDITOR_TEXT_RUS "c3_map.rus"
+#define FILE_EDITOR_MM_RUS "c3_map_mm.rus"
 
 static struct {
     struct {
@@ -150,7 +152,9 @@ static int load_files(const char *text_filename, const char *message_filename, i
 int lang_load(int is_editor)
 {
     if (is_editor) {
-        return load_files(FILE_EDITOR_TEXT_ENG, FILE_EDITOR_MM_ENG, MAY_BE_LOCALIZED);
+        return
+            load_files(FILE_EDITOR_TEXT_RUS, FILE_EDITOR_MM_RUS, MAY_BE_LOCALIZED) ||
+            load_files(FILE_EDITOR_TEXT_ENG, FILE_EDITOR_MM_ENG, MAY_BE_LOCALIZED);
     }
     // Prefer language files from localized dir, fall back to main dir
     return


### PR DESCRIPTION
eng-rus, rus-eng map editor
Bilingual map editor with the ability to switch the editor language through the settings menu.
Russian localization files must be located in a separate folder, for example rus (caesar3/rus)
[rus.zip](https://github.com/user-attachments/files/16059263/rus.zip)


