### PR TITLE
Allow players to continue playing 2 years after winning the second mission

### DIFF
--- a/src/window/victory_dialog.c
+++ b/src/window/victory_dialog.c
@@ -66,11 +66,13 @@ static void draw_foreground(void)
         } else {
             lang_text_draw_centered(62, 27, 80, 246, 480, FONT_NORMAL_GREEN);
         }
-        if (scenario_campaign_rank() >= 2 || scenario_is_custom()) {
-            // Continue for 2/5 years
+        if (scenario_campaign_rank() >= 1 || scenario_is_custom()) {
+            // Continue for 2 years
             large_label_draw(80, 272, 30, focus_button_id == 2);
             lang_text_draw_centered(62, 4, 80, 278, 480, FONT_NORMAL_GREEN);
-
+        }
+        if (scenario_campaign_rank() >= 2 || scenario_is_custom()) {
+            // Continue for 5 years
             large_label_draw(80, 304, 30, focus_button_id == 3);
             lang_text_draw_centered(62, 5, 80, 310, 480, FONT_NORMAL_GREEN);
         }
@@ -87,6 +89,8 @@ static void handle_input(const mouse *m, const hotkeys *h)
     int num_buttons;
     if (scenario_campaign_rank() >= 2 || scenario_is_custom()) {
         num_buttons = 3;
+    } else if (scenario_campaign_rank() == 1) {
+        num_buttons = 2;
     } else {
         num_buttons = 1;
     }


### PR DESCRIPTION
The second mission in the campaign ("Brindisium") is the last tutorial mission and ends very quickly, players may not have had the time to explore all the game mechanics. This change should allow the players to experiment with the game a bit more before playing the "real" missions.

From my own testing, save compatibility does not seem to be impacted. I can still load and play saves in C3 after winning the mission, and it will correctly trigger the victory screen after two years.

<img width="595" height="274" alt="image" src="https://github.com/user-attachments/assets/dc42c565-064b-492a-8994-49d4eb3f6a27" />
