### PR TITLE
Fix tooltips sometimes having a trailing new line

### DIFF
--- a/src/graphics/text.c
+++ b/src/graphics/text.c
@@ -389,15 +389,16 @@ int text_draw_multiline(const uint8_t *str, int x_offset, int y_offset, int box_
         }
         int current_width = 0;
         int line_index = 0;
-        while (has_more_characters && current_width < box_width) {
+        while (has_more_characters) {
             int word_num_chars;
             int word_width = get_word_width(str, font, &word_num_chars);
-            current_width += word_width;
-            if (current_width >= box_width) {
+            if (current_width + word_width >= box_width) {
                 if (current_width == 0) {
                     has_more_characters = 0;
                 }
+                break;
             } else {
+                current_width += word_width;
                 for (int i = 0; i < word_num_chars; i++) {
                     if (line_index == 0 && *str <= ' ') {
                         str++; // skip whitespace at start of line
@@ -435,13 +436,13 @@ int text_measure_multiline(const uint8_t *str, int box_width, font_t font, int *
         while (has_more_characters) {
             int word_num_chars;
             int word_width = get_word_width(str, font, &word_num_chars);
-            current_width += word_width;
-            if (current_width >= box_width) {
+            if (current_width + word_width >= box_width) {
                 if (current_width == 0) {
                     has_more_characters = 0;
                 }
                 break;
             } else {
+                current_width += word_width;
                 str += word_num_chars;
                 if (!*str) {
                     has_more_characters = 0;


### PR DESCRIPTION
From my understanding, the algorithm that calculated the required width for those tooltips updated the `current_width` variable before checking if it has enough space to do so, leading to a `current_width` (and a `largest_width`) larger than the `box_width`. So tooltips that had a longer text than `box_width` had a chance to fit their text in a single line even though two lines should be required.

With that fix, `current_width` is updated after checking that there is enough space.

Before:
<img width="289" height="119" alt="image" src="https://github.com/user-attachments/assets/5909f243-d748-4814-ae50-e434155c68df" /><br/>
<img width="227" height="66" alt="image" src="https://github.com/user-attachments/assets/773644ed-7d06-4a18-9af0-110502f62f56" />

After:
<img width="252" height="106" alt="image" src="https://github.com/user-attachments/assets/77534de5-110f-43ba-9ae9-9b047596c608" /><br/>
<img width="172" height="61" alt="image" src="https://github.com/user-attachments/assets/8834e5e7-8359-4a63-b671-69d3faa20a58" />

As as side not, the original Caesar 3 tooltips do not have this issue (but they appear to be a bit more longer?) so I guess this is a Julius issue.
