### PR TITLE
Do not show reservoir footprints when it cannot be built

### DIFF
--- a/src/building/construction.c
+++ b/src/building/construction.c
@@ -214,11 +214,9 @@ static int place_reservoir_and_aqueducts(
     }
     if (info->place_reservoir_at_start != PLACE_RESERVOIR_NO) {
         map_routing_block(x_start - 1, y_start - 1, 3);
-        mark_construction(x_start - 1, y_start - 1, 3, TERRAIN_ALL, 1);
     }
     if (info->place_reservoir_at_end != PLACE_RESERVOIR_NO) {
         map_routing_block(x_end - 1, y_end - 1, 3);
-        mark_construction(x_end - 1, y_end - 1, 3, TERRAIN_ALL, 1);
     }
     const int aqueduct_offsets_x[] = {0, 2, 0, -2};
     const int aqueduct_offsets_y[] = {-2, 0, 2, 0};
@@ -243,6 +241,12 @@ static int place_reservoir_and_aqueducts(
     }
     if (min_dist == 10000) {
         return 0;
+    }
+    if (info->place_reservoir_at_start != PLACE_RESERVOIR_NO) {
+        mark_construction(x_start - 1, y_start - 1, 3, TERRAIN_ALL, 1);
+    }
+    if (info->place_reservoir_at_end != PLACE_RESERVOIR_NO) {
+        mark_construction(x_end - 1, y_end - 1, 3, TERRAIN_ALL, 1);
     }
     int x_aq_start = aqueduct_offsets_x[min_dir_start];
     int y_aq_start = aqueduct_offsets_y[min_dir_start];
@@ -643,7 +647,6 @@ void building_construction_place(void)
     } else if (type == BUILDING_DRAGGABLE_RESERVOIR) {
         struct reservoir_info info;
         if (!place_reservoir_and_aqueducts(0, x_start, y_start, x_end, y_end, &info)) {
-            map_property_clear_constructing_and_deleted();
             city_warning_show(WARNING_CLEAR_LAND_NEEDED);
             return;
         }


### PR DESCRIPTION
When trying to build two linked reservoirs using the "draggable reservoir" feature, if the two reservoirs are in valid placements but the pathfinder does not find a way for the aqueduct, the reservoirs displayed some footprints on the map as if they were building but they are not.

This PR proposes to change that so that footprints are shown only if they could be built. 

Before:
<img width="800" height="435" alt="image" src="https://github.com/user-attachments/assets/1e6e111c-0a94-45d6-b6b7-109409723bcf" />

After:
<img width="716" height="408" alt="image" src="https://github.com/user-attachments/assets/2d2c16eb-ba44-49ea-bcbf-429efe66ec35" />

I removed the call to `map_property_clear_constructing_and_deleted` as, with that change, there does not seem to be any code path where both `place_reservoir_and_aqueducts` would return `0` and footprints would be shown on the map. Correct me if I am wrong though.

This is a change from the original Caesar 3 so feel free to close it if it is out of scope.

