### PR TITLE
Display the number of active wharfs in resource settings

### DIFF
--- a/src/city/buildings.c
+++ b/src/city/buildings.c
@@ -160,6 +160,11 @@ void city_buildings_add_working_dock(int building_id)
     ++city_data.building.working_docks;
 }
 
+int city_buildings_working_wharfs(void)
+{
+    return city_data.building.working_wharfs;
+}
+
 int city_buildings_shipyard_boats_requested(void)
 {
     return city_data.building.shipyard_boats_requested;

--- a/src/city/buildings.h
+++ b/src/city/buildings.h
@@ -33,6 +33,7 @@ void city_buildings_remove_dock(void);
 void city_buildings_reset_dock_wharf_counters(void);
 void city_buildings_add_working_wharf(int needs_fishing_boat);
 void city_buildings_add_working_dock(int building_id);
+int city_buildings_working_wharfs(void);
 int city_buildings_shipyard_boats_requested(void);
 int city_buildings_has_working_dock(void);
 int city_buildings_get_working_dock(int index);

--- a/src/window/resource_settings.c
+++ b/src/window/resource_settings.c
@@ -1,6 +1,7 @@
 #include "resource_settings.h"
 
 #include "building/count.h"
+#include "city/buildings.h"
 #include "city/resource.h"
 #include "core/calc.h"
 #include "core/image_group.h"
@@ -101,7 +102,18 @@ static void draw_foreground(void)
                 lang_text_draw(54, 13, 98 + width, 172, FONT_NORMAL_BLACK);
             }
         }
-    } else if (data.resource != RESOURCE_MEAT || !scenario_building_allowed(BUILDING_WHARF)) {
+    } else if (data.resource == RESOURCE_MEAT && scenario_building_allowed(BUILDING_WHARF)) {
+        int active_wharfs = city_buildings_working_wharfs() - city_buildings_shipyard_boats_requested();
+        if (active_wharfs > 0) {
+            // some wharfs are working and have boats
+            int width = text_draw_number(active_wharfs, '@', " ", 98, 172, FONT_NORMAL_BLACK);
+            if (active_wharfs == 1) {
+                lang_text_draw(54, 8, 98 + width, 172, FONT_NORMAL_BLACK);
+            } else {
+                lang_text_draw(54, 9, 98 + width, 172, FONT_NORMAL_BLACK);
+            }
+        }
+    } else {
         // we cannot produce this good
         lang_text_draw(54, 25, 98, 172, FONT_NORMAL_BLACK);
     }


### PR DESCRIPTION
This is a proposal to show the number of active wharfs to the resource settings of meat when the wharf is enabled. The other resources already show detailed information about the working and non-working industries but I could not find a way to retrieve all wharfs (including the non-working ones) so this is a quite limited addition. This means that if there are some non-active wharfs, they are completely ignored.

<img width="553" height="250" alt="image" src="https://github.com/user-attachments/assets/d053d1cc-88fd-44d3-a8ce-61847c7c8ae2" />

For now, a wharf is considered active when it has both some workforce and a boat.