### PR TITLE
Hide resources that cannot be traded in empire screen

### DIFF
--- a/src/window/empire.c
+++ b/src/window/empire.c
@@ -160,7 +160,7 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
         lang_text_draw(47, 10, x_offset + 44, y_offset + 40, FONT_NORMAL_GREEN);
         int index = 0;
         for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
-            if (!empire_object_city_sells_resource(object->id, resource)) {
+            if (!city->sells_resource[resource]) {
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
@@ -181,7 +181,7 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
         lang_text_draw(47, 9, x_offset + 44, y_offset + 71, FONT_NORMAL_GREEN);
         index = 0;
         for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
-            if (!empire_object_city_buys_resource(object->id, resource)) {
+            if (!city->buys_resource[resource]) {
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
@@ -201,7 +201,7 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
     } else { // trade is closed
         int index = lang_text_draw(47, 5, x_offset + 50, y_offset + 42, FONT_NORMAL_GREEN);
         for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
-            if (!empire_object_city_sells_resource(object->id, resource)) {
+            if (!city->sells_resource[resource]) {
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
@@ -210,7 +210,7 @@ static void draw_trade_city_info(const empire_object *object, const empire_city 
         }
         index += lang_text_draw(47, 4, x_offset + index + 100, y_offset + 42, FONT_NORMAL_GREEN);
         for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
-            if (!empire_object_city_buys_resource(object->id, resource)) {
+            if (!city->buys_resource[resource]) {
                 continue;
             }
             int trade_max = trade_route_limit(city->route_id, resource);
@@ -515,11 +515,11 @@ static void handle_input(const mouse *m, const hotkeys *h)
 
                     // we only want to handle resource buttons that the selected city trades
                     for (int resource = RESOURCE_MIN; resource < RESOURCE_MAX; resource++) {
-                        if (empire_object_city_sells_resource(obj->id, resource)) {
+                        if (city->sells_resource[resource]) {
                             generic_buttons_handle_mouse(m, x_offset + 120 + 104 * index_sell, y_offset + 31,
                                 generic_button_trade_resource + resource - 1, 1, &button_id);
                             index_sell++;
-                        } else if (empire_object_city_buys_resource(obj->id, resource)) {
+                        } else if (city->buys_resource[resource]) {
                             generic_buttons_handle_mouse(m, x_offset + 120 + 104 * index_buy, y_offset + 62,
                                 generic_button_trade_resource + resource - 1, 1, &button_id);
                             index_buy++;
@@ -570,7 +570,7 @@ static int get_tooltip_resource(tooltip_context *c)
     
     int item_offset = lang_text_get_width(47, 5, FONT_NORMAL_GREEN);
     for (int r = RESOURCE_MIN; r < RESOURCE_MAX; r++) {
-        if (empire_object_city_sells_resource(object_id, r)) {
+        if (city->sells_resource[r]) {
             if (is_mouse_hit(c, x_offset + 60 + item_offset, y_offset + 33, 26)) {
                 return r;
             }
@@ -579,7 +579,7 @@ static int get_tooltip_resource(tooltip_context *c)
     }
     item_offset += lang_text_get_width(47, 4, FONT_NORMAL_GREEN);
     for (int r = RESOURCE_MIN; r <= RESOURCE_MAX; r++) {
-        if (empire_object_city_buys_resource(object_id, r)) {
+        if (city->buys_resource[r]) {
             if (is_mouse_hit(c, x_offset + 110 + item_offset, y_offset + 33, 26)) {
                 return r;
             }


### PR DESCRIPTION
The empire screen show the trade information based on the empire objects, but everything else in the game uses the city objects data, e.g. to determine if a resource can be traded or if it should be shown in the trade advisor. In almost all cases, this is perfectly fine as the city objects data is initialized from the empire objects data.

In Damascus though (and potentially other cases), there is an inconsistency between the two: the empire screen shows that Tarsus could export marble even though it actually can't because the city data says the opposite.

This change is a proposal to actually use the city data instead of the empire data in the empire screen. IMHO given that the empire data is only used to initialize the city data, it makes little to no sense to continue showing the empire data the whole game when the city data is available. This should ensure that the data shown by the empire screen is actually relevant to the player.

Before:
<img width="502" height="203" alt="image" src="https://github.com/user-attachments/assets/df6edaca-3e18-4525-a2d3-6ba41eb8f312" /><br/>
<img width="470" height="200" alt="image" src="https://github.com/user-attachments/assets/c87bca90-a1f5-4f9a-9099-36b2e45a3bba" />

After:
<img width="503" height="215" alt="image" src="https://github.com/user-attachments/assets/55a73f03-79d6-4569-bf52-86a82fc3de6b" /><br/>
<img width="457" height="214" alt="image" src="https://github.com/user-attachments/assets/d5be660b-6112-429a-bc50-bd4684d26714" />

As far as I can tell, this does not affect the gameplay but this is a change from the original Caesar 3 anyway so feel free to close it if does not fit into the scope of Julius.