### PR TITLE
Apply display scale before sizing the startup window

### DIFF
--- a/src/platform/screen.c
+++ b/src/platform/screen.c
@@ -104,17 +104,33 @@ int platform_screen_create(const char *title, int display_scale_percentage, int 
 #endif
     set_scale_percentage(display_scale_percentage, 0, 0);
 
-    int width, height;
+    if (display_id < 0 || display_id >= SDL_GetNumVideoDisplays()) {
+        SDL_Log("Defaulting to display 0 instead of %d (num displays: %d)", display_id, SDL_GetNumVideoDisplays());
+        display_id = 0;
+    }
+    SDL_DisplayMode mode;
+    if (SDL_GetDesktopDisplayMode(display_id, &mode) != 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to get display mode: %s", SDL_GetError());
+        return 0;
+    }
+
+    int width = mode.w;
+    int height = mode.h;
     int fullscreen = system_is_fullscreen_only() ? 1 : setting_fullscreen();
-    if (fullscreen) {
-        SDL_DisplayMode mode;
-        SDL_GetDesktopDisplayMode(0, &mode);
-        width = mode.w;
-        height = mode.h;
-    } else {
-        setting_window(&width, &height);
-        width = scale_logical_to_pixels(width);
-        height = scale_logical_to_pixels(height);
+    if (!fullscreen) {
+#if SDL_VERSION_ATLEAST(2, 0, 5)
+        SDL_Rect bounds;
+        if (SDL_GetDisplayUsableBounds(display_id, &bounds) == 0) {
+            width = bounds.w;
+            height = bounds.h;
+        }
+#endif
+        // Apply the requested scale before converting the saved logical window size.
+        apply_max_scale(width, height);
+        int logical_width, logical_height;
+        setting_window(&logical_width, &logical_height);
+        width = SDL_min(width, scale_logical_to_pixels(logical_width));
+        height = SDL_min(height, scale_logical_to_pixels(logical_height));
     }
 
     platform_screen_destroy();
@@ -126,10 +142,6 @@ int platform_screen_create(const char *title, int display_scale_percentage, int 
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
 #endif
 
-    if (display_id < 0 || display_id >= SDL_GetNumVideoDisplays()) {
-        SDL_Log("Defaulting to display 0 instead of %d (num displays: %d)", display_id, SDL_GetNumVideoDisplays());
-        display_id = 0;
-    }
     SDL_Log("Creating screen %d x %d on display %d, %s, driver: %s", width, height, display_id,
         fullscreen ? "fullscreen" : "windowed", SDL_GetCurrentVideoDriver());
     Uint32 flags = SDL_WINDOW_RESIZABLE;
@@ -150,9 +162,7 @@ int platform_screen_create(const char *title, int display_scale_percentage, int 
         return 0;
     }
 
-    if (system_is_fullscreen_only()) {
-        SDL_GetWindowSize(SDL.window, &width, &height);
-    }
+    SDL_GetWindowSize(SDL.window, &width, &height);
 
     SDL_Log("Creating renderer");
     SDL.renderer = SDL_CreateRenderer(SDL.window, -1, SDL_RENDERER_PRESENTVSYNC);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,18 @@ add_executable(screen_test
 )
 target_compile_definitions(screen_test PRIVATE SDL_MAIN_HANDLED)
 target_link_libraries(screen_test ${SDL2_LIBRARY})
+if(WIN32)
+    find_file(SDL2_RUNTIME_LIBRARY SDL2.dll
+        HINTS ${SDL2_INCLUDE_DIR}/.. ${SDL_EXT_DIR} ${SDL_MINGW_EXT_DIR} ENV SDL2DIR
+        PATH_SUFFIXES bin lib/${SDL2_PROCESSOR_ARCH}
+    )
+    if(SDL2_RUNTIME_LIBRARY)
+        add_custom_command(TARGET screen_test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${SDL2_RUNTIME_LIBRARY}" "$<TARGET_FILE_DIR:screen_test>"
+        )
+    endif()
+endif()
 if(UNIX AND NOT APPLE)
     target_link_libraries(screen_test m)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,19 @@ add_executable(compare
     ${PROJECT_SOURCE_DIR}/src/core/zip.c
 )
 
+add_executable(screen_test
+    platform/screen.c
+    ${PROJECT_SOURCE_DIR}/src/platform/screen.c
+    ${PROJECT_SOURCE_DIR}/src/core/calc.c
+)
+target_compile_definitions(screen_test PRIVATE SDL_MAIN_HANDLED)
+target_link_libraries(screen_test ${SDL2_LIBRARY})
+if(UNIX AND NOT APPLE)
+    target_link_libraries(screen_test m)
+endif()
+add_test(NAME screen_startup_scale COMMAND screen_test)
+set_tests_properties(screen_startup_scale PROPERTIES ENVIRONMENT "SDL_VIDEODRIVER=dummy")
+
 add_executable(autopilot
     sav/sav_compare.c
     sav/run.c

--- a/test/platform/screen.c
+++ b/test/platform/screen.c
@@ -1,0 +1,130 @@
+#include "game/settings.h"
+#include "graphics/graphics.h"
+#include "graphics/screen.h"
+#include "input/cursor.h"
+#include "platform/cursor.h"
+#include "platform/screen.h"
+
+#include "SDL.h"
+
+#include <stdio.h>
+
+static struct {
+    int window_width;
+    int window_height;
+    int logical_width;
+    int logical_height;
+} data;
+
+// Replace game state and drawing dependencies; exercise the real SDL window and renderer.
+int setting_fullscreen(void)
+{
+    return 0;
+}
+
+void setting_window(int *width, int *height)
+{
+    *width = data.window_width;
+    *height = data.window_height;
+}
+
+void setting_set_display(int fullscreen, int width, int height)
+{
+    data.window_width = width;
+    data.window_height = height;
+}
+
+void screen_set_resolution(int width, int height)
+{
+    data.logical_width = width;
+    data.logical_height = height;
+}
+
+int screen_width(void)
+{
+    return data.logical_width;
+}
+
+int screen_height(void)
+{
+    return data.logical_height;
+}
+
+const void *graphics_canvas(void)
+{
+    return NULL;
+}
+
+const cursor *input_cursor_data(cursor_shape cursor_id, cursor_scale scale)
+{
+    return NULL;
+}
+
+int platform_cursor_get_texture_size(int width, int height)
+{
+    return 0;
+}
+
+static int test_requested_scale(int percentage)
+{
+    data.window_width = 640;
+    data.window_height = 480;
+    if (!platform_screen_create("Screen scale test", percentage, 0)) {
+        return 1;
+    }
+    int actual_scale = platform_screen_get_scale();
+    int failed = actual_scale != percentage || screen_width() != 640 || screen_height() != 480;
+    if (failed) {
+        fprintf(stderr, "Requested %d%% for 640 x 480, got %d%% for %d x %d\n",
+            percentage, actual_scale, screen_width(), screen_height());
+    }
+    platform_screen_destroy();
+    return failed;
+}
+
+static int test_window_fits_display(int logical_width, int logical_height, int percentage, int display_id)
+{
+    data.window_width = logical_width;
+    data.window_height = logical_height;
+    if (!platform_screen_create("Screen bounds test", percentage, display_id)) {
+        return 1;
+    }
+    SDL_DisplayMode mode;
+    if (SDL_GetDesktopDisplayMode(0, &mode) != 0) {
+        platform_screen_destroy();
+        return 1;
+    }
+    int actual_scale = platform_screen_get_scale();
+    int width = screen_width() * actual_scale / 100;
+    int height = screen_height() * actual_scale / 100;
+    int failed = screen_width() < 640 || screen_height() < 480 || width > mode.w || height > mode.h;
+    if (failed) {
+        fprintf(stderr, "Window %d x %d at %d%% does not fit display %d x %d or minimum 640 x 480\n",
+            width, height, actual_scale, mode.w, mode.h);
+    }
+    platform_screen_destroy();
+    return failed;
+}
+
+int main(int argc, char **argv)
+{
+    SDL_SetMainReady();
+    SDL_setenv("SDL_VIDEODRIVER", "dummy", 1);
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        fprintf(stderr, "Unable to initialize SDL: %s\n", SDL_GetError());
+        return 1;
+    }
+    int failed = test_requested_scale(150);
+    failed += test_requested_scale(50);
+    failed += test_requested_scale(100);
+    failed += test_requested_scale(150);
+    failed += test_window_fits_display(3840, 2160, 150, 0);
+    failed += test_window_fits_display(640, 480, 500, 0);
+    failed += test_window_fits_display(640, 480, 100, -1);
+    failed += test_window_fits_display(640, 480, 100, SDL_GetNumVideoDisplays());
+    SDL_Quit();
+    if (!failed) {
+        printf("All 8 screen startup checks passed\n");
+    }
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
Related issue: [#728](https://github.com/bvschaik/julius/issues/728)

## What was going wrong?

Starting Julius with `--display-scale 1.5` and a saved window size of 640x480 could still open a 640x480 window at 100% scale, instead of the expected 960x720 window at 150%.

The window dimensions were calculated before the requested scale took effect. When recreating the window, the previous scale could also affect its new size.

## What this changes

The requested scale is now applied before calculating the startup window size, using the selected display's available space.

- Keep the window within the available display area, including when the saved window size or requested scale is too large.
- Use the validated display selection when looking up the desktop mode.
- Initialize rendering with the actual window dimensions reported by SDL.

## Testing

Added a regression test using SDL's dummy video driver. It covers 50%, 100% and 150% scaling, repeated window creation, oversized saved windows, excessive scale, and invalid display selection.

- **Before the scaling fix:** five of the eight checks fail against the unchanged upstream code.
- **With the fix:** all eight checks pass, along with the full **37-test CTest suite**, locally on Windows with Visual Studio 2022 and SDL 2.32.10.
- Windows test builds copy the SDL runtime beside the test executable. The runtime search supports both MSVC's `include` / `lib/<architecture>` layout and MinGW's `include/SDL2` / `bin` layout, without relying on the directory variable overwritten by SDL_mixer discovery.
- Verified runtime discovery against the official SDL 2.32.8 MinGW packages for both x86 and x64: the previous search misses the DLL; the corrected search selects the matching architecture. The eight screen checks also pass locally with the official 64-bit MinGW SDL 2.32.8 DLL and the MSVC-built test executable.
- [GitHub Actions](https://github.com/bvschaik/julius/actions/runs/35469216148): the Windows MinGW 32-bit and 64-bit jobs both pass all 37 tests. `screen_startup_scale` completes in 1.66 s and 5.42 s respectively; the Windows MSVC job also passes.

## Relation to #728

This fixes a reproducible startup scaling problem related to #728. I have not reproduced the original reporter's exact 4K setup, so I am not claiming that this resolves the entire issue.
